### PR TITLE
Match motif length to phrase via sequence/diminution (#8)

### DIFF
--- a/src/e2eTest/java/com/motifgen/MotifLengthMatchingE2ETest.java
+++ b/src/e2eTest/java/com/motifgen/MotifLengthMatchingE2ETest.java
@@ -1,0 +1,264 @@
+package com.motifgen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.motifgen.generator.SentenceGenerator;
+import com.motifgen.loader.MotifLoader;
+import com.motifgen.model.Motif;
+import com.motifgen.model.Note;
+import com.motifgen.model.Sentence;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.sound.midi.MetaMessage;
+import javax.sound.midi.MidiEvent;
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.Sequence;
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.Track;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * End-to-end coverage for issue #8. Two fixture motifs:
+ *
+ * <ul>
+ *   <li>{@code shortMotifFile} - 4 quarter notes spanning ~1 bar of content
+ *       loaded into a 4-bar slot. Exercises the extension path.</li>
+ *   <li>{@code longMotifFile} - 16 half notes spanning ~8 bars of content
+ *       loaded into a 4-bar slot. Exercises the reduction path.</li>
+ * </ul>
+ */
+class MotifLengthMatchingE2ETest {
+
+  private static final int TICKS_PER_BEAT = 480;
+  private static final int BEATS_PER_BAR = 4;
+  private static final long BAR_TICKS = (long) BEATS_PER_BAR * TICKS_PER_BEAT;
+
+  @TempDir
+  static Path tempDir;
+
+  private static File shortMotifFile;
+  private static File longMotifFile;
+  private static File subSampleMotifFile;
+
+  @BeforeAll
+  static void createFixtures() throws Exception {
+    shortMotifFile = makeMidi(tempDir.resolve("short_motif.mid").toFile(),
+        new int[] {60, 62, 64, 65}, new long[] {TICKS_PER_BEAT, TICKS_PER_BEAT,
+            TICKS_PER_BEAT, TICKS_PER_BEAT});
+
+    int[] longPitches = {60, 62, 64, 65, 67, 65, 64, 62,
+                         60, 62, 64, 67, 65, 64, 62, 60};
+    long[] longDurs = new long[16];
+    for (int i = 0; i < 16; i++) longDurs[i] = 2L * TICKS_PER_BEAT; // half notes
+    longMotifFile = makeMidi(tempDir.resolve("long_motif.mid").toFile(),
+        longPitches, longDurs);
+
+    // 32 eighth-notes - reduction would clip below floor, sub-sampling needed
+    int[] subPitches = new int[32];
+    long[] subDurs = new long[32];
+    for (int i = 0; i < 32; i++) {
+      subPitches[i] = 60 + (i % 8);
+      subDurs[i] = TICKS_PER_BEAT / 2;
+    }
+    subSampleMotifFile = makeMidi(
+        tempDir.resolve("subsample_motif.mid").toFile(), subPitches, subDurs);
+  }
+
+  private static File makeMidi(File path, int[] pitches, long[] durations) throws Exception {
+    Sequence seq = new Sequence(Sequence.PPQ, TICKS_PER_BEAT);
+    Track track = seq.createTrack();
+
+    MetaMessage timeSig = new MetaMessage();
+    timeSig.setMessage(0x58, new byte[] {4, 2, 24, 8}, 4);
+    track.add(new MidiEvent(timeSig, 0));
+    MetaMessage tempo = new MetaMessage();
+    int mpq = 500_000;
+    tempo.setMessage(0x51,
+        new byte[] {(byte) (mpq >> 16), (byte) (mpq >> 8), (byte) mpq}, 3);
+    track.add(new MidiEvent(tempo, 0));
+
+    long tick = 0;
+    for (int i = 0; i < pitches.length; i++) {
+      ShortMessage on = new ShortMessage();
+      on.setMessage(ShortMessage.NOTE_ON, 0, pitches[i], 90);
+      track.add(new MidiEvent(on, tick));
+      ShortMessage off = new ShortMessage();
+      off.setMessage(ShortMessage.NOTE_OFF, 0, pitches[i], 0);
+      track.add(new MidiEvent(off, tick + durations[i]));
+      tick += durations[i];
+    }
+    MidiSystem.write(seq, 1, path);
+    return path;
+  }
+
+  /**
+   * Scenario: Phrase exactly fills the slot when motif is shorter.
+   */
+  @Test
+  void shortMotifFillsEachPhraseToTheBoundary() throws Exception {
+    Motif motif = MotifLoader.load(shortMotifFile.getAbsolutePath(), 4);
+    SentenceGenerator gen = new SentenceGenerator(2026L);
+    List<Sentence> candidates = gen.generate(motif);
+
+    for (Sentence s : candidates) {
+      for (Motif phrase : s.getPhrases()) {
+        long lastEnd = phrase.getNotes().stream()
+            .filter(n -> !n.isRest()).mapToLong(Note::endTick).max().orElse(0L);
+        long phraseTicks = (long) phrase.getBars() * phrase.getBeatsPerBar()
+            * phrase.getTicksPerBeat();
+        assertTrue(lastEnd >= phraseTicks - TICKS_PER_BEAT,
+            "phrase last note ends too early: lastEnd=" + lastEnd
+                + " phraseTicks=" + phraseTicks);
+      }
+    }
+  }
+
+  /**
+   * Scenario: Phrase exactly fills the slot when motif is longer.
+   */
+  @Test
+  void longMotifIsCompressedIntoEachPhrase() throws Exception {
+    Motif motif = MotifLoader.load(longMotifFile.getAbsolutePath(), 4);
+    SentenceGenerator gen = new SentenceGenerator(31L);
+    List<Sentence> candidates = gen.generate(motif);
+
+    for (Sentence s : candidates) {
+      for (Motif phrase : s.getPhrases()) {
+        long lastEnd = phrase.getNotes().stream()
+            .filter(n -> !n.isRest()).mapToLong(Note::endTick).max().orElse(0L);
+        long phraseTicks = (long) phrase.getBars() * phrase.getBeatsPerBar()
+            * phrase.getTicksPerBeat();
+        assertTrue(lastEnd <= phraseTicks + TICKS_PER_BEAT,
+            "compressed phrase overshoots: lastEnd=" + lastEnd
+                + " phraseTicks=" + phraseTicks);
+      }
+    }
+  }
+
+  /**
+   * Scenario: 13-bar regression is fixed - exported MIDI ends near 16 bars.
+   */
+  @Test
+  void exportedMidiSpansFullSixteenBars() throws Exception {
+    String outDir = tempDir.resolve("short_export").toString();
+    new File(outDir).mkdirs();
+
+    MotifGen.run(shortMotifFile.getAbsolutePath(), outDir, 120);
+
+    File[] files = new File(outDir).listFiles((d, n) -> n.endsWith(".mid"));
+    assertNotNull(files);
+    assertTrue(files.length >= 1);
+    for (File f : files) {
+      Sequence seq = MidiSystem.getSequence(f);
+      long lastNoteTick = 0L;
+      for (Track t : seq.getTracks()) {
+        for (int i = 0; i < t.size(); i++) {
+          MidiEvent e = t.get(i);
+          if (e.getMessage() instanceof ShortMessage sm
+              && sm.getCommand() == ShortMessage.NOTE_ON) {
+            lastNoteTick = Math.max(lastNoteTick, e.getTick());
+          }
+        }
+      }
+      double bars = (double) lastNoteTick / BAR_TICKS;
+      assertTrue(bars >= 15.0,
+          "exported MIDI " + f.getName() + " too short, bars=" + bars);
+    }
+  }
+
+  /**
+   * Scenario: A-section preserves motif identity across the length-matched phrase.
+   * Every A phrase's first tile should equal the source motif (modulo
+   * chromatic transposition into the candidate's key).
+   */
+  @Test
+  void aPhrasesStillExposeTheMotifAsTileZero() throws Exception {
+    Motif motif = MotifLoader.load(shortMotifFile.getAbsolutePath(), 4);
+    SentenceGenerator gen = new SentenceGenerator(7L);
+    List<Sentence> candidates = gen.generate(motif);
+
+    int notesInMotif = motif.getNotes().size();
+    List<Integer> motifIntervals = motifIntervals(motif);
+
+    for (Sentence s : candidates) {
+      String[] roles = s.getStructure().split(" ");
+      for (int p = 0; p < roles.length; p++) {
+        if (!roles[p].startsWith("a")) continue;
+        List<Note> aNotes = s.getPhrases().get(p).getNotes();
+        // First N notes of an A phrase must reproduce the motif's interval pattern
+        for (int i = 1; i < notesInMotif && i < aNotes.size(); i++) {
+          int actual = aNotes.get(i).pitch() - aNotes.get(i - 1).pitch();
+          assertEquals(motifIntervals.get(i - 1), actual,
+              "A phrase " + p + " of " + s
+                  + " breaks motif interval at idx " + i);
+        }
+      }
+    }
+  }
+
+  /**
+   * Scenario: Reduction with sub-sampling fallback still produces playable output.
+   */
+  @Test
+  void subSampleMotifProducesNoMicroNotes() throws Exception {
+    Motif motif = MotifLoader.load(subSampleMotifFile.getAbsolutePath(), 4);
+    SentenceGenerator gen = new SentenceGenerator(99L);
+    List<Sentence> candidates = gen.generate(motif);
+
+    for (Sentence s : candidates) {
+      for (Motif phrase : s.getPhrases()) {
+        for (Note n : phrase.getNotes()) {
+          if (!n.isRest()) {
+            assertTrue(n.durationTicks() >= 120,
+                "duration below 16th-note floor: " + n.durationTicks()
+                    + " in " + s);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Scenario: Existing #5 guarantees still hold after length matching.
+   */
+  @Test
+  void fleetIsStillTwentyDeterministicSentences() throws Exception {
+    Motif motif = MotifLoader.load(shortMotifFile.getAbsolutePath(), 4);
+    SentenceGenerator a = new SentenceGenerator(2024L);
+    SentenceGenerator b = new SentenceGenerator(2024L);
+    List<Sentence> fa = a.generate(motif);
+    List<Sentence> fb = b.generate(motif);
+
+    assertEquals(20, fa.size());
+    assertEquals(fa.size(), fb.size());
+
+    Set<String> templates = new HashSet<>();
+    Set<String> keys = new HashSet<>();
+    for (int i = 0; i < fa.size(); i++) {
+      assertEquals(fa.get(i).getStructure(), fb.get(i).getStructure(),
+          "deterministic structure at rank " + i);
+      assertEquals(fa.get(i).getKeyName(), fb.get(i).getKeyName(),
+          "deterministic key at rank " + i);
+      templates.add(fa.get(i).getStructure());
+      keys.add(fa.get(i).getKeyName());
+    }
+    assertEquals(4, templates.size());
+    assertEquals(5, keys.size());
+  }
+
+  private static List<Integer> motifIntervals(Motif motif) {
+    List<Note> n = motif.getNotes();
+    List<Integer> out = new java.util.ArrayList<>();
+    for (int i = 1; i < n.size(); i++) {
+      out.add(n.get(i).pitch() - n.get(i - 1).pitch());
+    }
+    return out;
+  }
+}

--- a/src/main/java/com/motifgen/generator/SentenceGenerator.java
+++ b/src/main/java/com/motifgen/generator/SentenceGenerator.java
@@ -2,6 +2,7 @@ package com.motifgen.generator;
 
 import com.motifgen.generator.catchy.AnnealingRefiner;
 import com.motifgen.generator.catchy.ClimaxPlacer;
+import com.motifgen.generator.catchy.MotifLengthMatcher;
 import com.motifgen.generator.catchy.PhraseSeeder;
 import com.motifgen.generator.catchy.StructuralPlan;
 import com.motifgen.generator.catchy.StructuralPlanner;
@@ -39,6 +40,7 @@ public class SentenceGenerator {
   private final StructuralPlanner planner = new StructuralPlanner();
   private final ClimaxPlacer climaxPlacer = new ClimaxPlacer();
   private final SentenceScorer scorer = new SentenceScorer();
+  private final MotifLengthMatcher lengthMatcher = new MotifLengthMatcher();
 
   public SentenceGenerator(long seed) {
     this.rootSeed = seed;
@@ -81,6 +83,9 @@ public class SentenceGenerator {
 
   private Sentence runPipeline(Motif motif, KeySignature key, String template, long seed) {
     StructuralPlan plan = planner.plan(motif, template, key);
+    long phraseTicks = (long) plan.phraseBars() * motif.getBeatsPerBar()
+        * motif.getTicksPerBeat();
+    Motif lengthMatched = lengthMatcher.match(motif, phraseTicks, key, seed);
 
     PhraseSeeder seeder = new PhraseSeeder(seed);
     List<Motif> phrases = new ArrayList<>();
@@ -89,7 +94,8 @@ public class SentenceGenerator {
     for (int i = 0; i < sections; i++) {
       char role = template.charAt(i);
       boolean isFinal = i == sections - 1;
-      PhraseSeeder.SeededPhrase seeded = seeder.seed(role, isFinal, motif, key);
+      PhraseSeeder.SeededPhrase seeded = seeder.seed(role, isFinal,
+          lengthMatched, key);
       Motif phrase = seeded.phrase().withBars(plan.phraseBars());
       phrases.add(phrase);
       if (seeded.immutable()) immutableIndices.add(i);

--- a/src/main/java/com/motifgen/generator/catchy/MotifLengthMatcher.java
+++ b/src/main/java/com/motifgen/generator/catchy/MotifLengthMatcher.java
@@ -1,0 +1,173 @@
+package com.motifgen.generator.catchy;
+
+import com.motifgen.model.Motif;
+import com.motifgen.model.Note;
+import com.motifgen.model.Sentence;
+import com.motifgen.scoring.SentenceScorer;
+import com.motifgen.theory.KeySignature;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adapts a motif's content duration to a phrase's target duration before any
+ * role-specific transformation is applied. Two paths:
+ *
+ * <ul>
+ *   <li><b>Extension</b> (motif content shorter than target): tile the phrase
+ *       with successive diatonic transpositions of the motif. The
+ *       {@link #match(Motif, long, KeySignature, long) match} method picks the
+ *       highest-scoring tile pattern from a small candidate set.</li>
+ *   <li><b>Reduction</b> (motif content longer than target): apply proportional
+ *       diminution; if scaling would push any duration below
+ *       {@link #MIN_DURATION_TICKS}, fall back to keeping every Nth note (with
+ *       the first and last sounding notes always preserved) and then scale.</li>
+ * </ul>
+ */
+public final class MotifLengthMatcher {
+
+  /** 16th note at 480 ticks per beat. */
+  public static final long MIN_DURATION_TICKS = 120L;
+
+  private static final int[][] A_CANDIDATE_PATTERNS = {
+      {0, 0, 0, 0},
+      {0, 1, 2, 3},
+      {0, 1, -1, 2},
+      {0, 0, 1, 0},
+      {0, -1, 1, -2}
+  };
+
+  private final MotifTransformer transformer = new MotifTransformer();
+  private final SentenceScorer scorer = new SentenceScorer();
+
+  public record ContentSpan(long startTick, long endTick, long durationTicks) {}
+
+  public ContentSpan span(Motif motif) {
+    Long start = null;
+    long end = 0L;
+    for (Note n : motif.getNotes()) {
+      if (n.isRest()) continue;
+      if (start == null) start = n.startTick();
+      end = Math.max(end, n.endTick());
+    }
+    if (start == null) return new ContentSpan(0L, 0L, 0L);
+    return new ContentSpan(start, end, end - start);
+  }
+
+  public Motif match(Motif motif, long phraseTicks, KeySignature key, long seed) {
+    long content = span(motif).durationTicks();
+    if (content == phraseTicks || content == 0L) return motif;
+    if (content > phraseTicks) return reduce(motif, phraseTicks);
+
+    Motif best = null;
+    double bestScore = Double.NEGATIVE_INFINITY;
+    for (int[] pattern : A_CANDIDATE_PATTERNS) {
+      Motif candidate = extend(motif, phraseTicks, key, pattern);
+      Sentence mock = new Sentence(
+          List.of(candidate, candidate, candidate, candidate),
+          "a a a a", key.name(), 0.0);
+      double score = scorer.score(mock).getScore();
+      if (score > bestScore) {
+        bestScore = score;
+        best = candidate;
+      }
+    }
+    return best;
+  }
+
+  Motif extend(Motif tile0, long phraseTicks, KeySignature key, int[] steps) {
+    if (steps == null || steps.length == 0) {
+      throw new IllegalArgumentException("steps must be non-empty");
+    }
+    long tileTicks = span(tile0).durationTicks();
+    if (tileTicks <= 0L) return tile0;
+
+    List<Note> out = new ArrayList<>();
+    long cursor = 0L;
+    int tileIdx = 0;
+    while (cursor < phraseTicks) {
+      Motif tile = transformer.diatonicTranspose(tile0,
+          steps[tileIdx % steps.length], key);
+      for (Note n : tile.getNotes()) {
+        long start = cursor + n.startTick();
+        if (start >= phraseTicks) break;
+        long end = Math.min(start + n.durationTicks(), phraseTicks);
+        out.add(new Note(n.pitch(), start, end - start, n.velocity()));
+      }
+      cursor += tileTicks;
+      tileIdx++;
+    }
+    if (!out.isEmpty()) {
+      Note last = out.get(out.size() - 1);
+      long maxEnd = Math.min(phraseTicks, last.startTick() + last.durationTicks());
+      if (maxEnd != last.endTick()) {
+        out.set(out.size() - 1, new Note(last.pitch(), last.startTick(),
+            maxEnd - last.startTick(), last.velocity()));
+      }
+      // If the last note ends short of the boundary by less than one tick,
+      // stretch it to land exactly on the boundary.
+      Note tail = out.get(out.size() - 1);
+      if (tail.endTick() < phraseTicks) {
+        out.set(out.size() - 1, new Note(tail.pitch(), tail.startTick(),
+            phraseTicks - tail.startTick(), tail.velocity()));
+      }
+    }
+    int bars = (int) Math.max(1L,
+        phraseTicks / ((long) tile0.getBeatsPerBar() * tile0.getTicksPerBeat()));
+    return new Motif(out, bars, tile0.getBeatsPerBar(), tile0.getTicksPerBeat());
+  }
+
+  Motif reduce(Motif motif, long phraseTicks) {
+    long content = span(motif).durationTicks();
+    if (content <= phraseTicks) return motif;
+
+    List<Note> sounding = new ArrayList<>();
+    for (Note n : motif.getNotes()) {
+      if (!n.isRest()) sounding.add(n);
+    }
+    if (sounding.isEmpty()) return motif;
+
+    int subsample = chooseSubsample(sounding, content, phraseTicks);
+    List<Note> kept = subsample(sounding, subsample);
+    long keptSpan = kept.get(kept.size() - 1).endTick() - kept.get(0).startTick();
+    if (keptSpan <= 0L) return motif;
+    double scale = (double) phraseTicks / (double) keptSpan;
+    long firstStart = kept.get(0).startTick();
+
+    List<Note> scaled = new ArrayList<>();
+    for (Note n : kept) {
+      long newStart = Math.round((n.startTick() - firstStart) * scale);
+      long newDur = Math.max(MIN_DURATION_TICKS, Math.round(n.durationTicks() * scale));
+      scaled.add(new Note(n.pitch(), newStart, newDur, n.velocity()));
+    }
+    int bars = (int) Math.max(1L,
+        phraseTicks / ((long) motif.getBeatsPerBar() * motif.getTicksPerBeat()));
+    return new Motif(scaled, bars, motif.getBeatsPerBar(), motif.getTicksPerBeat());
+  }
+
+  private static int chooseSubsample(List<Note> sounding, long content, long target) {
+    if (sounding.isEmpty()) return 1;
+    long minDur = sounding.stream().mapToLong(Note::durationTicks).min().orElse(0L);
+    if (minDur <= 0L) return 1;
+    double scale = (double) target / (double) content;
+    if (minDur * scale >= MIN_DURATION_TICKS) return 1;
+    int n = 2;
+    while (n <= sounding.size()) {
+      double effectiveScale = (double) target / ((double) content / n);
+      if (minDur * effectiveScale >= MIN_DURATION_TICKS) return n;
+      n++;
+    }
+    return n;
+  }
+
+  private static List<Note> subsample(List<Note> sounding, int n) {
+    if (n <= 1) return sounding;
+    List<Note> out = new ArrayList<>();
+    out.add(sounding.get(0));
+    for (int i = n; i < sounding.size() - 1; i += n) {
+      out.add(sounding.get(i));
+    }
+    Note last = sounding.get(sounding.size() - 1);
+    if (out.get(out.size() - 1) != last) out.add(last);
+    return out;
+  }
+}

--- a/src/main/java/com/motifgen/generator/catchy/MotifLengthMatcher.java
+++ b/src/main/java/com/motifgen/generator/catchy/MotifLengthMatcher.java
@@ -85,8 +85,10 @@ public final class MotifLengthMatcher {
     long cursor = 0L;
     int tileIdx = 0;
     while (cursor < phraseTicks) {
-      Motif tile = transformer.diatonicTranspose(tile0,
-          steps[tileIdx % steps.length], key);
+      int step = steps[tileIdx % steps.length];
+      Motif tile = step == 0
+          ? transformer.identity(tile0)
+          : transformer.diatonicTranspose(tile0, step, key);
       for (Note n : tile.getNotes()) {
         long start = cursor + n.startTick();
         if (start >= phraseTicks) break;

--- a/src/test/java/com/motifgen/generator/catchy/MotifLengthMatcherTest.java
+++ b/src/test/java/com/motifgen/generator/catchy/MotifLengthMatcherTest.java
@@ -1,0 +1,288 @@
+package com.motifgen.generator.catchy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.motifgen.model.Motif;
+import com.motifgen.model.Note;
+import com.motifgen.theory.KeySignature;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MotifLengthMatcherTest {
+
+  private static final int TPB = 480;
+  private static final int BPB = 4;
+  private static final long BAR_TICKS = (long) BPB * TPB;
+  private static final long PHRASE_TICKS = 4 * BAR_TICKS;
+
+  private Motif oneBarMotif() {
+    int[] pitches = {60, 62, 64, 65};
+    List<Note> notes = new ArrayList<>();
+    long tick = 0;
+    for (int p : pitches) {
+      notes.add(new Note(p, tick, TPB, 90));
+      tick += TPB;
+    }
+    return new Motif(notes, 4, BPB, TPB);
+  }
+
+  private Motif eightBarMotif() {
+    // 16 half-notes (each 2 beats) span exactly 8 bars at 4/4
+    int[] pitches = {60, 62, 64, 65, 67, 65, 64, 62,
+                     60, 62, 64, 67, 65, 64, 62, 60};
+    long halfNote = 2L * TPB;
+    List<Note> notes = new ArrayList<>();
+    long tick = 0;
+    for (int p : pitches) {
+      notes.add(new Note(p, tick, halfNote, 90));
+      tick += halfNote;
+    }
+    return new Motif(notes, 8, BPB, TPB);
+  }
+
+  @Test
+  void contentSpanIgnoresLeadingTrailingSilence() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    // notes start at tick 480 and end at tick 1920 (= 1 bar of music starting at beat 2)
+    List<Note> notes = List.of(
+        new Note(60, 480, TPB, 90),
+        new Note(62, 480 + TPB, TPB, 90),
+        new Note(64, 480 + 2 * TPB, TPB, 90));
+    Motif motif = new Motif(notes, 4, BPB, TPB);
+
+    MotifLengthMatcher.ContentSpan span = matcher.span(motif);
+
+    assertEquals(480, span.startTick());
+    assertEquals(480 + 3 * TPB, span.endTick());
+    assertEquals(3 * TPB, span.durationTicks());
+  }
+
+  @Test
+  void shorterMotifFillsPhraseExactlyAfterMatch() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    Motif matched = matcher.match(oneBarMotif(), PHRASE_TICKS,
+        KeySignature.major(0), 0L);
+
+    long lastEnd = matched.getNotes().stream()
+        .mapToLong(Note::endTick).max().orElse(0L);
+    assertTrue(lastEnd >= PHRASE_TICKS - TPB
+            && lastEnd <= PHRASE_TICKS + TPB,
+        "matched motif should end within one beat of the phrase boundary, got " + lastEnd);
+  }
+
+  @Test
+  void shorterMotifProducesAtLeastFourTilesWorthOfNotes() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    Motif source = oneBarMotif();
+    Motif matched = matcher.match(source, PHRASE_TICKS,
+        KeySignature.major(0), 0L);
+
+    // 4-bar phrase / 1-bar motif = 4 tiles, each with 4 notes => 16 notes
+    assertTrue(matched.getNotes().size() >= 4 * source.getNotes().size() - 1,
+        "expected ~16 notes (4 tiles), got " + matched.getNotes().size());
+  }
+
+  @Test
+  void extendWithAscendingPatternProducesAscendingTiles() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    Motif tile0 = oneBarMotif();
+    Motif tiled = matcher.extend(tile0, PHRASE_TICKS, KeySignature.major(0),
+        new int[] {0, 1, 2, 3});
+
+    // tile 0 first note: 60. tile 1 first note: D (62). tile 2: E (64). tile 3: F (65).
+    int notesPerTile = tile0.getNotes().size();
+    List<Note> all = tiled.getNotes();
+    assertEquals(60, all.get(0).pitch());
+    assertEquals(62, all.get(notesPerTile).pitch());
+    assertEquals(64, all.get(2 * notesPerTile).pitch());
+    assertEquals(65, all.get(3 * notesPerTile).pitch());
+  }
+
+  @Test
+  void extendPreservesScaleDegreePatternWithinEachTile() {
+    // Tonal sequence preserves SCALE-DEGREE motion, not chromatic intervals:
+    // moving the C-major motif {C,D,E,F} up by +1 step gives {D,E,F,G},
+    // whose chromatic intervals (2,1,2) differ from the source (2,2,1) but
+    // whose scale-degree positions (1,2,3,4) match exactly.
+    MotifTransformer transformer = new MotifTransformer();
+    KeySignature key = KeySignature.major(0);
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    int[] steps = {0, 1, -1, 2};
+
+    Motif tile0 = oneBarMotif();
+    Motif tiled = matcher.extend(tile0, PHRASE_TICKS, key, steps);
+
+    int notesPerTile = tile0.getNotes().size();
+    List<Note> all = tiled.getNotes();
+    int tiles = all.size() / notesPerTile;
+    for (int t = 0; t < tiles; t++) {
+      Motif expected = transformer.diatonicTranspose(tile0, steps[t], key);
+      for (int i = 0; i < notesPerTile; i++) {
+        assertEquals(expected.getNotes().get(i).pitch(),
+            all.get(t * notesPerTile + i).pitch(),
+            "tile " + t + " note " + i + " should match diatonic transpose");
+      }
+    }
+  }
+
+  @Test
+  void extendTrimsTrailingNoteToPhraseBoundary() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    // 1-bar motif, fits 4 times in 4 bars -> last tile fills exactly
+    Motif tiled = matcher.extend(oneBarMotif(), PHRASE_TICKS,
+        KeySignature.major(0), new int[] {0, 1, 2, 3});
+
+    long lastEnd = tiled.getNotes().stream()
+        .mapToLong(Note::endTick).max().orElse(0L);
+    assertEquals(PHRASE_TICKS, lastEnd,
+        "last note must end exactly at the phrase boundary");
+  }
+
+  @Test
+  void longerMotifIsReducedProportionallyWhenAboveFloor() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    Motif source = eightBarMotif(); // 16 half-notes spanning 8 bars
+    Motif matched = matcher.reduce(source, PHRASE_TICKS); // target 4 bars
+
+    // each half-note (960) should be halved to a quarter (480)
+    for (Note n : matched.getNotes()) {
+      assertEquals(TPB, n.durationTicks(),
+          "every note should be halved to a quarter");
+    }
+    long lastEnd = matched.getNotes().stream()
+        .mapToLong(Note::endTick).max().orElse(0L);
+    assertTrue(Math.abs(lastEnd - PHRASE_TICKS) <= TPB,
+        "reduced motif should end near the phrase boundary, got " + lastEnd);
+  }
+
+  @Test
+  void reductionAppliesSubSamplingWhenScaleWouldClipBelowFloor() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    // 32 eighth-notes (240 ticks each) span 4 bars at 4/4. Target = 1 bar
+    // means scale = 0.25, which would push every duration to 60 ticks
+    // (below the 120-tick floor) -> sub-sampling must kick in.
+    List<Note> notes = new ArrayList<>();
+    long tick = 0;
+    for (int i = 0; i < 32; i++) {
+      notes.add(new Note(60 + (i % 8), tick, TPB / 2, 90));
+      tick += TPB / 2;
+    }
+    Motif source = new Motif(notes, 4, BPB, TPB);
+
+    Motif matched = matcher.reduce(source, BAR_TICKS);
+
+    for (Note n : matched.getNotes()) {
+      assertTrue(n.durationTicks() >= 120,
+          "no duration should be below 120 ticks, got " + n.durationTicks());
+    }
+    assertTrue(matched.getNotes().size() < source.getNotes().size(),
+        "sub-sampling should drop some notes, kept "
+            + matched.getNotes().size() + " of " + source.getNotes().size());
+  }
+
+  @Test
+  void reductionPreservesFirstAndLastSoundingNote() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    List<Note> notes = new ArrayList<>();
+    long tick = 0;
+    for (int i = 0; i < 32; i++) {
+      notes.add(new Note(60 + (i % 8), tick, TPB / 2, 90));
+      tick += TPB / 2;
+    }
+    Motif source = new Motif(notes, 4, BPB, TPB);
+
+    Motif matched = matcher.reduce(source, BAR_TICKS);  // very tight target
+
+    // First note's pitch and last note's pitch are preserved.
+    assertEquals(source.getNotes().get(0).pitch(),
+        matched.getNotes().get(0).pitch());
+    assertEquals(source.getNotes().get(source.getNotes().size() - 1).pitch(),
+        matched.getNotes().get(matched.getNotes().size() - 1).pitch());
+  }
+
+  @Test
+  void matchReturnsMotifUnchangedWhenAlreadyExactlyPhraseSized() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    // Build a motif that exactly spans 4 bars
+    int[] pitches = {60, 62, 64, 65, 67, 65, 64, 62,
+                     60, 62, 64, 67, 65, 64, 62, 60};
+    List<Note> notes = new ArrayList<>();
+    long tick = 0;
+    for (int p : pitches) {
+      notes.add(new Note(p, tick, TPB, 90));
+      tick += TPB;
+    }
+    Motif source = new Motif(notes, 4, BPB, TPB);
+
+    Motif matched = matcher.match(source, PHRASE_TICKS,
+        KeySignature.major(0), 0L);
+
+    assertEquals(source.getNotes().size(), matched.getNotes().size());
+    for (int i = 0; i < source.getNotes().size(); i++) {
+      assertEquals(source.getNotes().get(i).pitch(),
+          matched.getNotes().get(i).pitch());
+    }
+  }
+
+  @Test
+  void matchIsDeterministicForSameSeed() {
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    Motif a = matcher.match(oneBarMotif(), PHRASE_TICKS,
+        KeySignature.major(0), 42L);
+    Motif b = matcher.match(oneBarMotif(), PHRASE_TICKS,
+        KeySignature.major(0), 42L);
+
+    assertEquals(a.getNotes().size(), b.getNotes().size());
+    for (int i = 0; i < a.getNotes().size(); i++) {
+      assertEquals(a.getNotes().get(i).pitch(), b.getNotes().get(i).pitch());
+    }
+  }
+
+  @Test
+  void matchPicksOneOfTheCandidatePatternsForExtension() {
+    // The matched motif should be one of the five candidate patterns,
+    // not e.g. the trivial repeat-only or untransposed copy.
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+    Motif matched = matcher.match(oneBarMotif(), PHRASE_TICKS,
+        KeySignature.major(0), 0L);
+
+    // Trivially: the matched output is at least as long as one tile and the
+    // first note matches the source motif's first note.
+    assertEquals(60, matched.getNotes().get(0).pitch());
+    // Some pattern (other than pure-repeat) should at least sometimes win;
+    // we don't assert which, but we do ensure at least 16 notes total.
+    assertTrue(matched.getNotes().size() >= 16,
+        "should produce >=16 notes for 4-bar phrase from 1-bar motif");
+  }
+
+  @Test
+  void differentMotifsUnlikelyToProduceIdenticalSequences() {
+    // Sanity: two distinct motifs should give distinct length-matched outputs.
+    MotifLengthMatcher matcher = new MotifLengthMatcher();
+
+    int[] aPitches = {60, 62, 64, 65};
+    int[] bPitches = {72, 70, 68, 67};
+    List<Note> a = new ArrayList<>();
+    List<Note> b = new ArrayList<>();
+    long tick = 0;
+    for (int i = 0; i < 4; i++) {
+      a.add(new Note(aPitches[i], tick, TPB, 90));
+      b.add(new Note(bPitches[i], tick, TPB, 90));
+      tick += TPB;
+    }
+    Motif motifA = new Motif(a, 4, BPB, TPB);
+    Motif motifB = new Motif(b, 4, BPB, TPB);
+
+    Motif matchedA = matcher.match(motifA, PHRASE_TICKS,
+        KeySignature.major(0), 0L);
+    Motif matchedB = matcher.match(motifB, PHRASE_TICKS,
+        KeySignature.major(0), 0L);
+
+    List<Integer> pitchesA = matchedA.getNotes().stream().map(Note::pitch).toList();
+    List<Integer> pitchesB = matchedB.getNotes().stream().map(Note::pitch).toList();
+    assertNotEquals(pitchesA, pitchesB);
+  }
+}


### PR DESCRIPTION
Closes #8.

## Summary

After #5 shipped, running the pipeline on a real MIDI file (TestMotif1.mid) produced 13-bar exports with most of each phrase silent. Diagnosis: when the motif file's musical content is shorter than the labelled bar count, the seeder copied 1 bar of music + 3 bars of silence into each phrase. This PR fixes that by adapting the motif's content duration to the phrase target before any role transform runs.

- New `MotifLengthMatcher` runs once per pipeline run.
  - **Extension** (motif content < phrase target): build a tonal sequence by tiling with successive diatonic transpositions of the motif. The matcher tries 5 candidate tile patterns (pure repeat, ascending, mirror, echo, descending mirror) and picks the highest-scoring one via `SentenceScorer` in a mock-sentence context.
  - **Reduction** (motif content > phrase target): proportional diminution. If scaling would push any duration below 120 ticks (16th note at 480 tpb), sub-sample by keeping every Nth note (preserving first and last sounding notes) before scaling.
  - Tile 0 always preserves the motif's exact interval pattern — only transposed tiles get the in-key snap.
- `SentenceGenerator.runPipeline` now calls `lengthMatcher.match()` once before the per-phrase loop and feeds the length-matched motif to `PhraseSeeder`. The role transforms (A=identity, B=transpose/invert, C=retrograde/transpose) operate on the length-matched motif, so the tonal-sequence shape carries through B/C automatically.

Design wiki: https://github.com/astonehal/MotifGen/wiki/Design-Issue-8

## Test plan
- [x] `./gradlew check` passes - unit tests + E2E + both 80% JaCoCo coverage gates green.
- [x] 13 unit tests for `MotifLengthMatcher` covering content-span, scale-degree preservation, tile truncation, proportional diminution, sub-sampling fallback, first/last preservation, and determinism.
- [x] 6 E2E scenarios in `MotifLengthMatchingE2ETest` covering all #8 acceptance criteria.
- [x] `./gradlew run --args="TestMotif1.mid ./output 120 midi"` now produces 16.25-bar exports with ~164 notes per sentence (vs ~13 bars / ~16 notes before).