### PR TITLE
Add rhythm guitar backing track (#18)

### DIFF
--- a/src/e2eTest/java/com/motifgen/RhythmGuitarE2ETest.java
+++ b/src/e2eTest/java/com/motifgen/RhythmGuitarE2ETest.java
@@ -1,0 +1,365 @@
+package com.motifgen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.motifgen.exporter.MidiExporter;
+import com.motifgen.guitar.backing.BackingCatchinessScorer;
+import com.motifgen.guitar.backing.BackingConsonanceScorer;
+import com.motifgen.guitar.backing.BackingTrack;
+import com.motifgen.guitar.backing.BackingTrackGenerator;
+import com.motifgen.guitar.backing.BackingTrackSelector;
+import com.motifgen.guitar.backing.GuitarChordVoicer;
+import com.motifgen.guitar.backing.HarmonyApproach;
+import com.motifgen.guitar.backing.RhythmDensityPlan;
+import com.motifgen.guitar.backing.RhythmDensityPlanner;
+import com.motifgen.guitar.backing.StrumPattern;
+import com.motifgen.guitar.backing.VoicingType;
+import com.motifgen.model.Motif;
+import com.motifgen.model.Note;
+import com.motifgen.model.Sentence;
+import com.motifgen.sentiment.SentimentProfile;
+import com.motifgen.theory.KeySignature;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sound.midi.MidiSystem;
+import javax.sound.midi.Sequence;
+import javax.sound.midi.ShortMessage;
+import javax.sound.midi.Track;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * End-to-end tests for issue #18 (Add Rhythm Guitar Backing Track).
+ *
+ * <p>These tests drive the full backing track pipeline — harmony generation,
+ * rhythm density planning, strum pattern selection, chord voicing, scoring,
+ * and MIDI export — against realistic note sequences, mirroring the Gherkin
+ * acceptance criteria.
+ */
+class RhythmGuitarE2ETest {
+
+  private static final int TICKS_PER_BEAT = 480;
+  private static final int BEATS_PER_BAR  = 4;
+  private static final int DEFAULT_TEMPO  = 120;
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private Motif motifOf(int[] pitches) {
+    List<Note> notes = new ArrayList<>();
+    long tick = 0;
+    for (int pitch : pitches) {
+      notes.add(new Note(pitch, tick, TICKS_PER_BEAT, 80));
+      tick += TICKS_PER_BEAT;
+    }
+    int bars = Math.max(1, (int) Math.ceil((double) pitches.length / BEATS_PER_BAR));
+    return new Motif(notes, bars, BEATS_PER_BAR, TICKS_PER_BEAT);
+  }
+
+  /** Build a 4-bar C-major sentence from the given pitches. */
+  private Sentence sentenceOf(int[] pitches) {
+    Motif motif = motifOf(pitches);
+    return new Sentence(List.of(motif), "a", "C major", 50.0);
+  }
+
+  /** A simple 8-note in-range C-major scale melody. */
+  private Sentence cMajorSentence() {
+    return sentenceOf(new int[]{60, 62, 64, 65, 67, 69, 71, 72});
+  }
+
+  /** Counts active (true) slots in a strum pattern array. */
+  private int activeStrums(boolean[] pattern) {
+    int count = 0;
+    for (boolean b : pattern) if (b) count++;
+    return count;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 1: Second MIDI track on channel 2, program 25, pitches in [40, 76]
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 1.
+   * Given a melody sentence and a generated backing track
+   * When the two-track MIDI export is performed
+   * Then the MIDI file has exactly 2 tracks (Type-1 SMF)
+   * And track 1 (the backing) contains a program-change event for program 25
+   * And all note-on events in track 1 have pitches in [40, 76].
+   */
+  @Test
+  void given_melodyAndBackingTrack_when_exported_then_twoTrackSMFWithCorrectProgramAndPitchRange()
+      throws Exception {
+    Sentence melody = cMajorSentence();
+    SentimentProfile profile = SentimentProfile.fromLabel("HAPPY");
+    BackingTrack backing = BackingTrackGenerator.generate(melody, profile);
+
+    File tmpFile = Files.createTempFile("motifgen-e2e-", ".mid").toFile();
+    tmpFile.deleteOnExit();
+    MidiExporter.export(melody, backing, tmpFile, DEFAULT_TEMPO);
+
+    Sequence seq = MidiSystem.getSequence(tmpFile);
+
+    // The exported file must be a Type-1 SMF
+    assertEquals(Sequence.PPQ, seq.getDivisionType(),
+        "SMF division type must be PPQ");
+    assertEquals(2, seq.getTracks().length,
+        "Exported MIDI must contain exactly 2 tracks (Type-1 SMF)");
+
+    Track backingTrack = seq.getTracks()[1];
+
+    // Track 1 must have a program-change event selecting GM program 25.
+    // In MIDI, PROGRAM_CHANGE data byte 0 is the program number (0-indexed),
+    // but the MidiExporter writes backing.program() - 1 = 24 (0-indexed) on
+    // MIDI channel 1 (0-indexed), which equals GM program 25.
+    boolean foundProgramChange = false;
+    boolean allNotesInRange = true;
+
+    for (int i = 0; i < backingTrack.size(); i++) {
+      javax.sound.midi.MidiEvent event = backingTrack.get(i);
+      javax.sound.midi.MidiMessage msg = event.getMessage();
+      if (msg instanceof ShortMessage sm) {
+        int cmd = sm.getCommand();
+        if (cmd == ShortMessage.PROGRAM_CHANGE && sm.getChannel() == BackingTrack.BACKING_CHANNEL) {
+          // SM getData1() returns the 0-indexed program; GM program 25 = data1 24
+          assertEquals(BackingTrack.GUITAR_PROGRAM - 1, sm.getData1(),
+              "Program-change data byte must select GM program 25 (data1=24)");
+          foundProgramChange = true;
+        }
+        if (cmd == ShortMessage.NOTE_ON && sm.getData2() > 0
+            && sm.getChannel() == BackingTrack.BACKING_CHANNEL) {
+          int pitch = sm.getData1();
+          if (pitch < 40 || pitch > 76) {
+            allNotesInRange = false;
+          }
+        }
+      }
+    }
+
+    assertTrue(foundProgramChange,
+        "Track 1 must contain a program-change event on MIDI channel 2 (index 1)");
+    assertTrue(allNotesInRange,
+        "All note-on events in track 1 must have pitches in [40, 76]");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 2: Five harmony approaches produce candidates
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 2.
+   * Given any of the 5 HarmonyApproach values
+   * When BackingTrackGenerator is invoked
+   * Then BackingTrackGenerator produces a non-empty BackingTrack.
+   */
+  @ParameterizedTest(name = "HarmonyApproach.{0} produces a non-empty BackingTrack")
+  @EnumSource(HarmonyApproach.class)
+  void given_harmonyApproach_when_backingTrackGenerated_then_nonEmptyBackingTrackProduced(
+      HarmonyApproach approach) {
+
+    Sentence melody = cMajorSentence();
+    SentimentProfile profile = SentimentProfile.fromVA(0.6, 0.6);
+
+    // Exercise the specific approach by using the selector's internal helper:
+    // We invoke the full generator (which evaluates all 30 combinations) and
+    // separately verify that the named approach itself generates chord slots.
+    List<com.motifgen.guitar.backing.ChordSlot> slots = approach.generateChords(
+        melody.getAllNotes(),
+        KeySignature.major(0), // C major — matches cMajorSentence()
+        profile);
+
+    // The approach must return at least one chord slot for a non-empty melody
+    assertFalse(slots.isEmpty(),
+        "HarmonyApproach." + approach + " must produce at least one chord slot");
+
+    // The full generator must also return a non-null, program-correct result
+    BackingTrack backing = BackingTrackGenerator.generate(melody, profile);
+    assertNotNull(backing, "BackingTrackGenerator must return a non-null BackingTrack");
+    assertEquals(BackingTrack.GUITAR_PROGRAM, backing.program(),
+        "BackingTrack program must be 25 (Acoustic Guitar)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 3: Rhythm density adapts to arousal
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 3.
+   * Given a high-arousal sentiment and a low-arousal sentiment
+   * When strum patterns are generated via the full pipeline
+   * Then the high-arousal pattern has more active strum events per bar than
+   *   the low-arousal pattern.
+   */
+  @Test
+  void given_highVsLowArousal_when_strumPatternsGenerated_then_highArousalIsDenser() {
+    Sentence melody = cMajorSentence();
+
+    // High arousal (0.9) → EIGHTH or SIXTEENTH subdivision → DRIVING or FUNK archetype
+    SentimentProfile highArousal = SentimentProfile.fromVA(0.6, 0.9);
+    // Low arousal (0.1) → WHOLE subdivision → BALLAD archetype
+    SentimentProfile lowArousal  = SentimentProfile.fromVA(0.6, 0.1);
+
+    RhythmDensityPlan highPlan = RhythmDensityPlanner.plan(highArousal, "A", melody);
+    RhythmDensityPlan lowPlan  = RhythmDensityPlanner.plan(lowArousal,  "A", melody);
+
+    boolean[] highPattern = StrumPattern.forSentiment(
+        highArousal, VoicingType.OPEN, DEFAULT_TEMPO, highPlan);
+    boolean[] lowPattern  = StrumPattern.forSentiment(
+        lowArousal, VoicingType.OPEN, DEFAULT_TEMPO, lowPlan);
+
+    int highActive = activeStrums(highPattern);
+    int lowActive  = activeStrums(lowPattern);
+
+    assertTrue(highActive > lowActive,
+        "High-arousal strum pattern (active=%d) must be denser than low-arousal (active=%d)"
+            .formatted(highActive, lowActive));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 4: Strumming pattern responds to sentiment
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 4.
+   * Given HAPPY sentiment and MELANCHOLY sentiment
+   * When strum patterns are generated
+   * Then the HAPPY pattern differs from the MELANCHOLY pattern (brighter/denser).
+   */
+  @Test
+  void given_happyVsMelancholySentiment_when_strumPatternGenerated_then_patternsAreDifferent() {
+    Sentence melody = cMajorSentence();
+
+    // HAPPY (valence=0.75, arousal=0.70) → high energy, brighter pattern
+    // GLOOMY (valence=0.20, arousal=0.20) → low energy, sparse ballad pattern
+    SentimentProfile happy  = SentimentProfile.fromLabel("HAPPY");
+    SentimentProfile gloomy = SentimentProfile.fromLabel("GLOOMY");
+
+    RhythmDensityPlan happyPlan  = RhythmDensityPlanner.plan(happy,  "A", melody);
+    RhythmDensityPlan gloomyPlan = RhythmDensityPlanner.plan(gloomy, "A", melody);
+
+    boolean[] happyPattern  = StrumPattern.forSentiment(
+        happy,  VoicingType.OPEN, DEFAULT_TEMPO, happyPlan);
+    boolean[] gloomyPattern = StrumPattern.forSentiment(
+        gloomy, VoicingType.OPEN, DEFAULT_TEMPO, gloomyPlan);
+
+    int happyActive  = activeStrums(happyPattern);
+    int gloomyActive = activeStrums(gloomyPattern);
+
+    // HAPPY must produce a denser (brighter) strum pattern than GLOOMY
+    assertTrue(happyActive > gloomyActive,
+        "HAPPY strum pattern (active=%d) must be denser/brighter than GLOOMY (active=%d)"
+            .formatted(happyActive, gloomyActive));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 6: Top candidate selected automatically
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 6.
+   * Given any valid Sentence and SentimentProfile
+   * When BackingTrackSelector is invoked
+   * Then it always returns a non-null, non-empty BackingTrack.
+   */
+  @Test
+  void given_validSentenceAndProfile_when_selectorRuns_then_alwaysReturnsNonNullBackingTrack() {
+    // Exercise several representative profiles to guard against edge cases
+    List<SentimentProfile> profiles = List.of(
+        SentimentProfile.fromLabel("HAPPY"),
+        SentimentProfile.fromLabel("SAD"),
+        SentimentProfile.fromLabel("ANGRY"),
+        SentimentProfile.fromLabel("RELAXED"),
+        SentimentProfile.fromVA(0.0, 0.0),
+        SentimentProfile.fromVA(1.0, 1.0),
+        SentimentProfile.fromVA(0.5, 0.5)
+    );
+
+    Sentence melody = cMajorSentence();
+
+    for (SentimentProfile profile : profiles) {
+      BackingTrack result = BackingTrackSelector.select(melody, profile);
+      assertNotNull(result,
+          "BackingTrackSelector must never return null (profile: " + profile.closestLabel() + ")");
+      assertEquals(BackingTrack.GUITAR_PROGRAM, result.program(),
+          "BackingTrack program must always be 25");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 7: BackingConsonanceScorer always returns a value in [0, 100]
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 7.
+   * Given any valid melody and backed chord voicings
+   * When BackingConsonanceScorer.score() is called
+   * Then the returned value is always in [0, 100].
+   */
+  @Test
+  void given_voicedChordsAndMelody_when_consonanceScorerRuns_then_scoreIsInValidRange() {
+    Sentence melody = cMajorSentence();
+    List<Note> melodyNotes = melody.getAllNotes();
+
+    // Test all 5 harmony approaches to exercise a variety of chord structures
+    for (HarmonyApproach approach : HarmonyApproach.values()) {
+      List<com.motifgen.guitar.backing.ChordSlot> slots = approach.generateChords(
+          melodyNotes,
+          KeySignature.major(0), // C major — matches cMajorSentence()
+          SentimentProfile.fromVA(0.5, 0.5));
+
+      List<com.motifgen.guitar.backing.VoicedChord> voiced =
+          GuitarChordVoicer.voice(slots, VoicingType.OPEN, TICKS_PER_BEAT);
+
+      double score = BackingConsonanceScorer.score(voiced, melodyNotes, TICKS_PER_BEAT);
+
+      assertTrue(score >= 0.0 && score <= 100.0,
+          "BackingConsonanceScorer must return [0,100] for approach "
+              + approach + "; got " + score);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 8: BackingCatchinessScorer always returns a value in [0, 100]
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Scenario 8.
+   * Given any valid melody sentence, voiced chords, and strum pattern
+   * When BackingCatchinessScorer.score() is called
+   * Then the returned value is always in [0, 100].
+   */
+  @Test
+  void given_sentenceAndVoicedChords_when_catchinessScorerRuns_then_scoreIsInValidRange() {
+    Sentence melody = cMajorSentence();
+    List<Note> melodyNotes = melody.getAllNotes();
+    SentimentProfile profile = SentimentProfile.fromVA(0.5, 0.5);
+
+    for (HarmonyApproach approach : HarmonyApproach.values()) {
+      List<com.motifgen.guitar.backing.ChordSlot> slots = approach.generateChords(
+          melodyNotes,
+          KeySignature.major(0), // C major — matches cMajorSentence()
+          profile);
+
+      List<com.motifgen.guitar.backing.VoicedChord> voiced =
+          GuitarChordVoicer.voice(slots, VoicingType.OPEN, TICKS_PER_BEAT);
+
+      RhythmDensityPlan plan = RhythmDensityPlanner.plan(profile, "A", melody);
+      boolean[] strumPat = StrumPattern.forSentiment(profile, VoicingType.OPEN, DEFAULT_TEMPO, plan);
+
+      double score = BackingCatchinessScorer.score(melody, voiced, strumPat, TICKS_PER_BEAT);
+
+      assertTrue(score >= 0.0 && score <= 100.0,
+          "BackingCatchinessScorer must return [0,100] for approach "
+              + approach + "; got " + score);
+    }
+  }
+}

--- a/src/e2eTest/java/com/motifgen/TrailingSilenceTilingE2ETest.java
+++ b/src/e2eTest/java/com/motifgen/TrailingSilenceTilingE2ETest.java
@@ -263,6 +263,9 @@ class TrailingSilenceTilingE2ETest {
           if (!(event.getMessage() instanceof ShortMessage sm)) continue;
           if (sm.getCommand() != ShortMessage.NOTE_ON) continue;
           if (sm.getData2() == 0) continue;
+          // Only check melody channel (channel 0); backing guitar (channel 1) may
+          // legitimately place notes throughout the bar to fill rhythmic gaps.
+          if (sm.getChannel() != 0) continue;
           long tick = event.getTick();
           if (tick < 7680L) {
             assertTrue(tick <= phantomBoundaryTick,

--- a/src/main/java/com/motifgen/MotifGen.java
+++ b/src/main/java/com/motifgen/MotifGen.java
@@ -4,6 +4,8 @@ import com.motifgen.exporter.MidiExporter;
 import com.motifgen.exporter.MusicXMLExporter;
 import com.motifgen.generator.SentenceGenerator;
 import com.motifgen.guitar.PlayabilityGate;
+import com.motifgen.guitar.backing.BackingTrack;
+import com.motifgen.guitar.backing.BackingTrackGenerator;
 import com.motifgen.loader.MotifLoader;
 import com.motifgen.model.Motif;
 import com.motifgen.model.Sentence;
@@ -177,7 +179,8 @@ public class MotifGen {
 
             if (format == OutputFormat.MIDI || format == OutputFormat.BOTH) {
                 File midFile = new File(outDir, baseName + ".mid");
-                MidiExporter.export(sentence, midFile, tempo);
+                BackingTrack backing = BackingTrackGenerator.generate(sentence, profile);
+                MidiExporter.export(sentence, backing, midFile, tempo);
                 System.out.println("    Exported MIDI to: " + midFile.getAbsolutePath());
             }
 

--- a/src/main/java/com/motifgen/MotifGen.java
+++ b/src/main/java/com/motifgen/MotifGen.java
@@ -179,7 +179,7 @@ public class MotifGen {
 
             if (format == OutputFormat.MIDI || format == OutputFormat.BOTH) {
                 File midFile = new File(outDir, baseName + ".mid");
-                BackingTrack backing = BackingTrackGenerator.generate(sentence, profile);
+                BackingTrack backing = BackingTrackGenerator.generate(sentence, profile, tempo);
                 MidiExporter.export(sentence, backing, midFile, tempo);
                 System.out.println("    Exported MIDI to: " + midFile.getAbsolutePath());
             }

--- a/src/main/java/com/motifgen/exporter/MidiExporter.java
+++ b/src/main/java/com/motifgen/exporter/MidiExporter.java
@@ -1,5 +1,7 @@
 package com.motifgen.exporter;
 
+import com.motifgen.guitar.backing.BackingTrack;
+import com.motifgen.guitar.backing.ChanneledNote;
 import com.motifgen.model.Note;
 import com.motifgen.model.Sentence;
 
@@ -65,5 +67,109 @@ public class MidiExporter {
 
     public static void export(Sentence sentence, File outputFile) throws Exception {
         export(sentence, outputFile, DEFAULT_TEMPO_BPM);
+    }
+
+    /**
+     * Exports a Type-1 (multi-track) MIDI file containing the melody on track 0
+     * (channel 0, 0-indexed) and the rhythm guitar backing on track 1
+     * (channel 1, 0-indexed = MIDI channel 2; program-change to program 25
+     * is written at tick 0 of track 1).
+     *
+     * <p>The existing single-track {@link #export(Sentence, File)} overload is
+     * unchanged.
+     *
+     * @param melody     the melody sentence
+     * @param backing    the backing track produced by BackingTrackGenerator
+     * @param outputFile destination MIDI file
+     * @throws Exception if MIDI I/O fails
+     */
+    public static void export(Sentence melody, BackingTrack backing, File outputFile)
+            throws Exception {
+        export(melody, backing, outputFile, DEFAULT_TEMPO_BPM);
+    }
+
+    /**
+     * Exports a Type-1 MIDI file with melody and backing tracks at the specified tempo.
+     *
+     * @param melody     the melody sentence
+     * @param backing    the backing track
+     * @param outputFile destination MIDI file
+     * @param tempoBpm   tempo in beats per minute
+     * @throws Exception if MIDI I/O fails
+     */
+    public static void export(Sentence melody, BackingTrack backing, File outputFile,
+            int tempoBpm) throws Exception {
+        List<Note> melodyNotes = melody.getAllNotes();
+        int ticksPerBeat = melody.getPhrases().getFirst().getTicksPerBeat();
+
+        Sequence sequence = new Sequence(Sequence.PPQ, ticksPerBeat);
+
+        // --- Track 0: melody (channel 0) ---
+        Track melodyTrack = sequence.createTrack();
+
+        int microsPerBeat = 60_000_000 / tempoBpm;
+        byte[] tempoData = {
+                (byte) ((microsPerBeat >> 16) & 0xFF),
+                (byte) ((microsPerBeat >> 8)  & 0xFF),
+                (byte) (microsPerBeat & 0xFF)
+        };
+        melodyTrack.add(new MidiEvent(new MetaMessage(0x51, tempoData, 3), 0));
+
+        byte[] timeSigData = {4, 2, 24, 8};
+        melodyTrack.add(new MidiEvent(new MetaMessage(0x58, timeSigData, 4), 0));
+
+        String trackName = "MotifGen: " + melody.getKeyName() + " (" + melody.getStructure() + ")";
+        melodyTrack.add(
+                new MidiEvent(new MetaMessage(0x03, trackName.getBytes(), trackName.length()), 0));
+
+        for (Note note : melodyNotes) {
+            if (note.isRest()) continue;
+            int pitch    = Math.max(0, Math.min(127, note.pitch()));
+            int velocity = Math.max(1, Math.min(127, note.velocity()));
+            melodyTrack.add(new MidiEvent(
+                    new ShortMessage(ShortMessage.NOTE_ON, CHANNEL, pitch, velocity),
+                    note.startTick()));
+            melodyTrack.add(new MidiEvent(
+                    new ShortMessage(ShortMessage.NOTE_OFF, CHANNEL, pitch, 0),
+                    note.endTick()));
+        }
+
+        long melodyEnd = melodyNotes.stream().mapToLong(Note::endTick).max().orElse(0)
+                + ticksPerBeat;
+        melodyTrack.add(new MidiEvent(new MetaMessage(0x2F, new byte[0], 0), melodyEnd));
+
+        // --- Track 1: backing guitar (channel 1, program 25) ---
+        Track backingTrack = sequence.createTrack();
+
+        String backingName = "Rhythm Guitar";
+        backingTrack.add(
+                new MidiEvent(new MetaMessage(0x03, backingName.getBytes(),
+                        backingName.length()), 0));
+
+        int backingChannel = BackingTrack.BACKING_CHANNEL;
+        // Program change: select GM program 25 (Acoustic Guitar – Steel)
+        backingTrack.add(new MidiEvent(
+                new ShortMessage(ShortMessage.PROGRAM_CHANGE, backingChannel,
+                        backing.program() - 1, 0),
+                0));
+
+        for (ChanneledNote cn : backing.notes()) {
+            Note note = cn.note();
+            if (note.isRest()) continue;
+            int pitch    = Math.max(0, Math.min(127, note.pitch()));
+            int velocity = Math.max(1, Math.min(127, note.velocity()));
+            backingTrack.add(new MidiEvent(
+                    new ShortMessage(ShortMessage.NOTE_ON, backingChannel, pitch, velocity),
+                    note.startTick()));
+            backingTrack.add(new MidiEvent(
+                    new ShortMessage(ShortMessage.NOTE_OFF, backingChannel, pitch, 0),
+                    note.endTick()));
+        }
+
+        long backingEnd = backing.notes().stream()
+                .mapToLong(cn -> cn.note().endTick()).max().orElse(melodyEnd) + ticksPerBeat;
+        backingTrack.add(new MidiEvent(new MetaMessage(0x2F, new byte[0], 0), backingEnd));
+
+        MidiSystem.write(sequence, 1, outputFile);
     }
 }

--- a/src/main/java/com/motifgen/generator/SentenceGenerator.java
+++ b/src/main/java/com/motifgen/generator/SentenceGenerator.java
@@ -181,7 +181,7 @@ public class SentenceGenerator {
     if (!immutableIndices.contains(finalPhraseIdx)) {
       refined = forceFinalNoteToTonic(refined, key, finalPhraseIdx);
     }
-    return refined;
+    return clampPitchRange(refined, 48, 84);
   }
 
   private static Sentence forceFinalNoteToTonic(Sentence sentence, KeySignature key,
@@ -267,6 +267,28 @@ public class SentenceGenerator {
           original.getBeatsPerBar(), original.getTicksPerBeat()));
     }
     return split;
+  }
+
+  private static Sentence clampPitchRange(Sentence sentence, int minPitch, int maxPitch) {
+    List<Motif> clamped = new ArrayList<>();
+    for (Motif phrase : sentence.getPhrases()) {
+      List<Note> notes = new ArrayList<>();
+      for (Note n : phrase.getNotes()) {
+        if (n.isRest()) {
+          notes.add(n);
+        } else {
+          int pitch = n.pitch();
+          while (pitch > maxPitch && pitch - 12 >= minPitch) pitch -= 12;
+          while (pitch < minPitch && pitch + 12 <= maxPitch) pitch += 12;
+          pitch = Math.max(minPitch, Math.min(maxPitch, pitch));
+          notes.add(new Note(pitch, n.startTick(), n.durationTicks(), n.velocity()));
+        }
+      }
+      clamped.add(new Motif(notes, phrase.getBars(), phrase.getBeatsPerBar(),
+          phrase.getTicksPerBeat()));
+    }
+    return new Sentence(clamped, sentence.getStructure(), sentence.getKeyName(),
+        sentence.getScore());
   }
 
   private static String structureStringFor(String template) {

--- a/src/main/java/com/motifgen/generator/catchy/AnnealingRefiner.java
+++ b/src/main/java/com/motifgen/generator/catchy/AnnealingRefiner.java
@@ -109,7 +109,7 @@ public final class AnnealingRefiner {
     switch (weakest) {
       case REPETITION -> applyRepetitionMutation(phrases, phraseIdx, notes, soundingIdx, rng);
       case CONTOUR -> applyContourMutation(notes, soundingIdx, key, rng);
-      case COMPACTNESS -> applyCompactnessMutation(notes, soundingIdx);
+      case COMPACTNESS -> applyCompactnessMutation(notes, soundingIdx, key);
       case RHYTHM -> applyRhythmMutation(notes, soundingIdx, rng, profile);
       case CONVENTIONALITY -> applyConventionalityMutation(notes, soundingIdx, key, rng);
       case HOOK -> applyHookMutation(notes, soundingIdx, rng);
@@ -150,7 +150,8 @@ public final class AnnealingRefiner {
         orig.durationTicks(), orig.velocity()));
   }
 
-  private void applyCompactnessMutation(List<Note> notes, List<Integer> soundingIdx) {
+  private void applyCompactnessMutation(List<Note> notes, List<Integer> soundingIdx,
+      KeySignature key) {
     int mean = 0;
     for (int idx : soundingIdx) mean += notes.get(idx).pitch();
     mean /= soundingIdx.size();
@@ -166,7 +167,9 @@ public final class AnnealingRefiner {
     }
     Note target = notes.get(worstIdx);
     int shift = target.pitch() > mean ? -12 : 12;
-    int newPitch = Math.max(0, Math.min(127, target.pitch() + shift));
+    int shifted = Math.max(0, Math.min(127, target.pitch() + shift));
+    // Snap to nearest in-key pitch so octave shifts don't introduce accidentals
+    int newPitch = nearestInKey(shifted, key);
     notes.set(worstIdx, new Note(newPitch, target.startTick(),
         target.durationTicks(), target.velocity()));
   }

--- a/src/main/java/com/motifgen/generator/catchy/ClimaxPlacer.java
+++ b/src/main/java/com/motifgen/generator/catchy/ClimaxPlacer.java
@@ -21,7 +21,7 @@ public final class ClimaxPlacer {
   private static final int DEFAULT_LIFT_SEMITONES = 3;
   private static final int MIN_LIFT_SEMITONES     = 1;
   private static final int MAX_LIFT_SEMITONES     = 7;
-  private static final int MAX_PITCH              = 100;
+  private static final int MAX_PITCH              = 84; // C6 — top of comfortable melodic range
 
   /** Backward-compatible overload — uses the default lift of 3 semitones. */
   public Motif enforceClimax(Motif motif, int climaxIndex, KeySignature key) {

--- a/src/main/java/com/motifgen/generator/catchy/MotifTransformer.java
+++ b/src/main/java/com/motifgen/generator/catchy/MotifTransformer.java
@@ -48,7 +48,7 @@ public final class MotifTransformer {
     return switch (op) {
       case INVERT -> {
         int pivot = firstSoundingPitch(motif);
-        yield invert(motif, pivot);
+        yield invertInKey(motif, pivot, key);
       }
       case RETROGRADE -> retrograde(motif);
       case DIATONIC_UP_2 -> diatonicTranspose(motif, 2, key);
@@ -73,6 +73,24 @@ public final class MotifTransformer {
         out.add(n);
       } else {
         int newPitch = shiftBySteps(n.pitch(), scaleSteps, key);
+        out.add(new Note(newPitch, n.startTick(), n.durationTicks(), n.velocity()));
+      }
+    }
+    return new Motif(out, motif.getBars(), motif.getBeatsPerBar(), motif.getTicksPerBeat());
+  }
+
+  /**
+   * Mirrors every sounding pitch around {@code pivotPitch} and snaps the result
+   * to the nearest in-key pitch. Rests are preserved.
+   */
+  public Motif invertInKey(Motif motif, int pivotPitch, KeySignature key) {
+    List<Note> out = new ArrayList<>();
+    for (Note n : motif.getNotes()) {
+      if (n.isRest()) {
+        out.add(n);
+      } else {
+        int raw = Math.max(0, Math.min(127, 2 * pivotPitch - n.pitch()));
+        int newPitch = nearestInKey(raw, key);
         out.add(new Note(newPitch, n.startTick(), n.durationTicks(), n.velocity()));
       }
     }

--- a/src/main/java/com/motifgen/generator/catchy/PhraseSeeder.java
+++ b/src/main/java/com/motifgen/generator/catchy/PhraseSeeder.java
@@ -85,7 +85,7 @@ public final class PhraseSeeder {
     return switch (choice) {
       case TRANSPOSE_FIFTH_UP    -> transformer.diatonicTranspose(motif,  step + 3, key);
       case TRANSPOSE_FOURTH_DOWN -> transformer.diatonicTranspose(motif, -(step + 2), key);
-      case INVERT                -> transformer.invert(motif, firstSoundingPitch(motif));
+      case INVERT                -> transformer.apply(MotifTransformer.Op.INVERT, motif, key);
     };
   }
 
@@ -127,10 +127,4 @@ public final class PhraseSeeder {
     return Math.max(0, Math.min(127, chosen));
   }
 
-  private static int firstSoundingPitch(Motif motif) {
-    for (Note n : motif.getNotes()) {
-      if (!n.isRest()) return n.pitch();
-    }
-    return 60;
-  }
 }

--- a/src/main/java/com/motifgen/generator/catchy/SyncopationApplier.java
+++ b/src/main/java/com/motifgen/generator/catchy/SyncopationApplier.java
@@ -30,6 +30,15 @@ public final class SyncopationApplier {
 
   private SyncopationApplier() {}
 
+  private static int nextSoundingIndex(List<Integer> soundingIdx, int currentNoteIdx) {
+    boolean found = false;
+    for (int si : soundingIdx) {
+      if (found) return si;
+      if (si == currentNoteIdx) found = true;
+    }
+    return -1;
+  }
+
   /**
    * Returns a new motif with syncopation applied according to the profile.
    *
@@ -67,6 +76,10 @@ public final class SyncopationApplier {
       Note n = notes.get(idx);
       long newStart = n.startTick() + shift;
       long newDur   = n.durationTicks() - shift;
+
+      // Skip if the shift would collide with the next sounding note's start tick.
+      int nextIdx = nextSoundingIndex(soundingIdx, idx);
+      if (nextIdx >= 0 && newStart >= notes.get(nextIdx).startTick()) continue;
 
       // Clamp: newStart must be < phraseEnd; newDur >= 1
       newStart = Math.min(newStart, phraseEnd - 1);

--- a/src/main/java/com/motifgen/guitar/backing/BackingCatchinessScorer.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingCatchinessScorer.java
@@ -1,0 +1,177 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Note;
+import com.motifgen.model.Sentence;
+import com.motifgen.scoring.SentenceScorer;
+
+import java.util.List;
+
+/**
+ * Scores the catchiness of a backing track relative to the melody.
+ *
+ * <p>Formula:
+ * <pre>
+ *   catchiness = 0.40 × base_melody
+ *              + 0.25 × rhythmic_interlock
+ *              + 0.20 × hook_reinforcement
+ *              + 0.15 × harmonic_interest
+ *
+ *   rhythmic_interlock = 0.5 × interlock + 0.3 × pattern_repetition − 0.2 × busyness_penalty
+ * </pre>
+ *
+ * <p>All component scores are in [0, 1] before the final × 100 normalisation.
+ */
+public final class BackingCatchinessScorer {
+
+  private static final double W_BASE_MELODY      = 0.40;
+  private static final double W_RHYTHMIC_INTERLOCK = 0.25;
+  private static final double W_HOOK_REINFORCEMENT  = 0.20;
+  private static final double W_HARMONIC_INTEREST   = 0.15;
+
+  private static final double W_INTERLOCK         = 0.5;
+  private static final double W_PATTERN_REPETITION = 0.3;
+  private static final double W_BUSYNESS_PENALTY   = 0.2;
+
+  /** Maximum distinct chord changes considered fully harmonically interesting. */
+  private static final int MAX_DISTINCT_CHANGES = 8;
+
+  private BackingCatchinessScorer() {}
+
+  /**
+   * Computes a normalised catchiness score (0–100).
+   *
+   * @param sentence   the melody sentence
+   * @param voiced     voiced backing chords
+   * @param strumPat   strum pattern boolean array (true = active strum slot)
+   * @param ppq        ticks per quarter note
+   * @return score in [0, 100]
+   */
+  public static double score(
+      Sentence sentence, List<VoicedChord> voiced, boolean[] strumPat, int ppq) {
+
+    List<Note> melodyNotes = sentence.getAllNotes();
+
+    double baseMelody      = baseMelodyScore(sentence);
+    double rhythmicInterlock = rhythmicInterlock(melodyNotes, strumPat, ppq);
+    double hookReinforcement = hookReinforcement(melodyNotes, strumPat, ppq);
+    double harmonicInterest  = harmonicInterest(voiced);
+
+    double raw = W_BASE_MELODY * baseMelody
+        + W_RHYTHMIC_INTERLOCK * rhythmicInterlock
+        + W_HOOK_REINFORCEMENT * hookReinforcement
+        + W_HARMONIC_INTEREST  * harmonicInterest;
+
+    return Math.max(0.0, Math.min(100.0, raw * 100.0));
+  }
+
+  // -----------------------------------------------------------------------
+  // Component scorers
+  // -----------------------------------------------------------------------
+
+  /** Delegates to SentenceScorer and normalises to [0, 1]. */
+  private static double baseMelodyScore(Sentence sentence) {
+    SentenceScorer scorer = new SentenceScorer();
+    double total = scorer.breakdown(sentence).total(); // 0–100
+    return total / 100.0;
+  }
+
+  /**
+   * Rhythmic interlock: how well the backing strum offsets complement melody onsets.
+   * <pre>
+   *   0.5 × interlock + 0.3 × pattern_repetition − 0.2 × busyness_penalty
+   * </pre>
+   */
+  private static double rhythmicInterlock(
+      List<Note> melodyNotes, boolean[] strumPat, int ppq) {
+    if (strumPat.length == 0 || melodyNotes.isEmpty()) return 0.5;
+
+    double interlock = computeInterlock(melodyNotes, strumPat, ppq);
+    double patternRepetition = computePatternRepetition(strumPat);
+    double busyness = computeBusyness(strumPat);
+
+    double raw = W_INTERLOCK * interlock
+        + W_PATTERN_REPETITION * patternRepetition
+        - W_BUSYNESS_PENALTY * busyness;
+    return Math.max(0.0, Math.min(1.0, raw));
+  }
+
+  /**
+   * Interlock: fraction of strum slots that do NOT coincide with melody onsets
+   * (complementarity — strums fill the gaps).
+   */
+  private static double computeInterlock(
+      List<Note> melodyNotes, boolean[] strumPat, int ppq) {
+    int patLen = strumPat.length;
+    if (patLen == 0) return 0.5;
+    long slotTicks = (long) ppq / 2; // eighth-note slot size
+
+    int activeStrums = 0;
+    int complementaryStrums = 0;
+    for (int i = 0; i < patLen; i++) {
+      if (!strumPat[i]) continue;
+      activeStrums++;
+      long strumTick = i * slotTicks;
+      boolean melodyOnset = melodyNotes.stream()
+          .anyMatch(n -> !n.isRest() && Math.abs(n.startTick() - strumTick) < slotTicks / 2);
+      if (!melodyOnset) complementaryStrums++;
+    }
+    return activeStrums == 0 ? 0.5 : (double) complementaryStrums / activeStrums;
+  }
+
+  /** Pattern repetition: how regular the strum pattern is (low entropy = high repetition). */
+  private static double computePatternRepetition(boolean[] strumPat) {
+    // Measure: if first half equals second half → perfect repetition
+    int half = strumPat.length / 2;
+    if (half == 0) return 0.5;
+    int matches = 0;
+    for (int i = 0; i < half; i++) {
+      if (strumPat[i] == strumPat[i + half]) matches++;
+    }
+    return (double) matches / half;
+  }
+
+  /** Busyness penalty: proportion of active strum slots (more active = busier). */
+  private static double computeBusyness(boolean[] strumPat) {
+    if (strumPat.length == 0) return 0.0;
+    int active = 0;
+    for (boolean b : strumPat) if (b) active++;
+    return (double) active / strumPat.length;
+  }
+
+  /**
+   * Hook reinforcement: proportion of strum accents that align with melody notes
+   * occurring at strong beat positions (beat 1 and beat 3 in 4/4).
+   */
+  private static double hookReinforcement(
+      List<Note> melodyNotes, boolean[] strumPat, int ppq) {
+    if (strumPat.length == 0) return 0.5;
+    long slotTicks = (long) ppq / 2;
+    // Strong beat slots: 0 and 4 in an 8-slot bar
+    int[] strongSlots = {0, 4};
+    int aligned = 0;
+    int checked = 0;
+    for (int slot : strongSlots) {
+      if (slot >= strumPat.length) continue;
+      checked++;
+      if (!strumPat[slot]) continue;
+      long strumTick = slot * slotTicks;
+      boolean melodyPresent = melodyNotes.stream()
+          .anyMatch(n -> !n.isRest() && Math.abs(n.startTick() - strumTick) < slotTicks);
+      if (melodyPresent) aligned++;
+    }
+    return checked == 0 ? 0.5 : (double) aligned / checked;
+  }
+
+  /**
+   * Harmonic interest: number of distinct chord changes normalised by
+   * {@link #MAX_DISTINCT_CHANGES}.
+   */
+  private static double harmonicInterest(List<VoicedChord> voiced) {
+    if (voiced.isEmpty()) return 0.0;
+    long distinctChanges = voiced.stream()
+        .map(VoicedChord::notes)
+        .distinct()
+        .count();
+    return Math.min(1.0, (double) distinctChanges / MAX_DISTINCT_CHANGES);
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/BackingConsonanceScorer.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingConsonanceScorer.java
@@ -1,0 +1,111 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Note;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Scores the consonance of a voiced backing track against a melody.
+ *
+ * <p>For each (chord note, melody note, beat-strength) triple the interval
+ * class is looked up in {@link #CONSONANCE_TABLE}; the resulting values are
+ * weighted by beat strength and normalised to 0–100.
+ */
+public final class BackingConsonanceScorer {
+
+  /**
+   * Consonance table keyed by interval class in semitones (0–11).
+   * Values from the acceptance criteria.
+   */
+  static final Map<Integer, Double> CONSONANCE_TABLE = Map.ofEntries(
+      Map.entry(0,  1.0),
+      Map.entry(1,  0.1),
+      Map.entry(2,  0.4),
+      Map.entry(3,  0.8),
+      Map.entry(4,  0.9),
+      Map.entry(5,  0.7),
+      Map.entry(6,  0.1),
+      Map.entry(7,  1.0),
+      Map.entry(8,  0.7),
+      Map.entry(9,  0.8),
+      Map.entry(10, 0.4),
+      Map.entry(11, 0.1)
+  );
+
+  private BackingConsonanceScorer() {}
+
+  /**
+   * Computes a normalised consonance score (0–100) for the voiced chords
+   * against the melody.
+   *
+   * @param voicedChords  voiced chords from the backing track
+   * @param melodyNotes   all melody notes in time order
+   * @param ppq           ticks per quarter note (used to derive beat strength)
+   * @return consonance score 0–100
+   */
+  public static double score(
+      List<VoicedChord> voicedChords, List<Note> melodyNotes, int ppq) {
+    if (voicedChords.isEmpty() || melodyNotes.isEmpty()) return 0.0;
+
+    double weightedSum = 0.0;
+    double totalWeight = 0.0;
+
+    for (VoicedChord vc : voicedChords) {
+      // Find melody notes that sound during this chord
+      List<Note> concurrent = concurrentMelodyNotes(vc, melodyNotes);
+      if (concurrent.isEmpty()) continue;
+
+      for (Note chordNote : vc.notes()) {
+        if (chordNote.isRest()) continue;
+        for (Note melodyNote : concurrent) {
+          if (melodyNote.isRest()) continue;
+          double beatStrength = beatStrength(melodyNote.startTick(), ppq);
+          int interval = intervalClass(chordNote.pitch(), melodyNote.pitch());
+          double consonance = CONSONANCE_TABLE.getOrDefault(interval, 0.5);
+          weightedSum += consonance * beatStrength;
+          totalWeight += beatStrength;
+        }
+      }
+    }
+
+    if (totalWeight == 0.0) return 50.0; // no overlap — neutral score
+    double raw = weightedSum / totalWeight; // 0–1
+    return Math.max(0.0, Math.min(100.0, raw * 100.0));
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  /** Returns melody notes that overlap with the voiced chord's time span. */
+  private static List<Note> concurrentMelodyNotes(VoicedChord vc, List<Note> melody) {
+    if (vc.notes().isEmpty()) return List.of();
+    long chordStart = vc.startTick();
+    // Determine chord end from the notes themselves
+    long chordEnd = vc.notes().stream().mapToLong(Note::endTick).max().orElse(chordStart + 1);
+    return melody.stream()
+        .filter(n -> !n.isRest()
+            && n.startTick() < chordEnd
+            && n.endTick() > chordStart)
+        .toList();
+  }
+
+  /**
+   * Beat strength: beat 1 (tick % ticksPerBar == 0) → 1.0; beat 3 → 0.75;
+   * beats 2 and 4 → 0.5; off-beats → 0.25.
+   */
+  private static double beatStrength(long tick, int ppq) {
+    long ticksPerBar = ppq * 4L;
+    long posInBar = tick % ticksPerBar;
+    if (posInBar == 0)         return 1.0;
+    if (posInBar == ppq * 2L)  return 0.75;
+    if (posInBar % ppq == 0)   return 0.5;
+    return 0.25;
+  }
+
+  /** Interval class: absolute semitone distance mod 12. */
+  private static int intervalClass(int pitch1, int pitch2) {
+    return Math.abs(pitch1 - pitch2) % 12;
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/BackingTrack.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingTrack.java
@@ -1,0 +1,22 @@
+package com.motifgen.guitar.backing;
+
+import java.util.List;
+
+/**
+ * Immutable record representing the complete rhythm guitar backing track.
+ *
+ * <p>All notes are on MIDI channel index 1 (= MIDI channel 2, 0-indexed)
+ * using GM program 25 (Acoustic Guitar – Steel).
+ *
+ * @param notes         channeled notes (channel=1, program=25)
+ * @param program       GM program number (always 25)
+ * @param combinedScore 0.5 × consonance + 0.5 × catchiness, normalised 0–100
+ */
+public record BackingTrack(List<ChanneledNote> notes, int program, double combinedScore) {
+
+  /** GM program number for Acoustic Guitar – Steel. */
+  public static final int GUITAR_PROGRAM = 25;
+
+  /** MIDI channel index for the backing track (0-indexed = channel 2). */
+  public static final int BACKING_CHANNEL = 1;
+}

--- a/src/main/java/com/motifgen/guitar/backing/BackingTrackGenerator.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingTrackGenerator.java
@@ -15,13 +15,18 @@ public final class BackingTrackGenerator {
   private BackingTrackGenerator() {}
 
   /**
-   * Generates the best backing track for the given melody sentence and
-   * sentiment profile.
+   * Generates the best backing track for the given melody sentence and sentiment profile.
    *
-   * @param sentence the melody sentence (supplies melody notes, key, structure)
-   * @param profile  sentiment profile (supplies valence and arousal)
+   * @param sentence  the melody sentence (supplies melody notes, key, structure)
+   * @param profile   sentiment profile (supplies valence and arousal)
+   * @param tempoBpm  playback tempo in BPM (used for strum-pattern tempo gating)
    * @return the highest-scoring backing track
    */
+  public static BackingTrack generate(Sentence sentence, SentimentProfile profile, int tempoBpm) {
+    return BackingTrackSelector.select(sentence, profile, tempoBpm);
+  }
+
+  /** Backward-compatible overload defaulting to 120 BPM. */
   public static BackingTrack generate(Sentence sentence, SentimentProfile profile) {
     return BackingTrackSelector.select(sentence, profile);
   }

--- a/src/main/java/com/motifgen/guitar/backing/BackingTrackGenerator.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingTrackGenerator.java
@@ -1,0 +1,28 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Sentence;
+import com.motifgen.sentiment.SentimentProfile;
+
+/**
+ * Facade for generating a rhythm guitar backing track.
+ *
+ * <p>Delegates to {@link BackingTrackSelector} which evaluates all
+ * {@link HarmonyApproach} × {@link VoicingType} combinations and returns
+ * the highest-scoring {@link BackingTrack}.
+ */
+public final class BackingTrackGenerator {
+
+  private BackingTrackGenerator() {}
+
+  /**
+   * Generates the best backing track for the given melody sentence and
+   * sentiment profile.
+   *
+   * @param sentence the melody sentence (supplies melody notes, key, structure)
+   * @param profile  sentiment profile (supplies valence and arousal)
+   * @return the highest-scoring backing track
+   */
+  public static BackingTrack generate(Sentence sentence, SentimentProfile profile) {
+    return BackingTrackSelector.select(sentence, profile);
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/BackingTrackSelector.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingTrackSelector.java
@@ -9,11 +9,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Evaluates all combinations of {@link HarmonyApproach} (5) ×
- * {@link VoicingType} (6) = 30 candidates and returns the {@link BackingTrack}
- * with the highest combined score.
+ * Evaluates all five {@link HarmonyApproach} values against a sentiment-driven
+ * {@link VoicingType} and returns the {@link BackingTrack} with the highest
+ * combined score.
  *
- * <p>Combined score formula: {@code 0.5 × consonance + 0.5 × catchiness}.
+ * <p>Voicing is selected once from the {@link SentimentProfile} (not through
+ * scoring) to prevent low-complexity voicings (e.g. power chords) from
+ * dominating the consonance metric. The five harmony approaches then compete
+ * through the combined score formula: {@code 0.5 × consonance + 0.5 × catchiness}.
  */
 public final class BackingTrackSelector {
 
@@ -24,7 +27,10 @@ public final class BackingTrackSelector {
   private BackingTrackSelector() {}
 
   /**
-   * Selects the best backing track from all approach × voicing combinations.
+   * Selects the best backing track.
+   *
+   * <p>The voicing type is derived from the sentiment profile; the five
+   * harmony approaches then compete via combined score.
    *
    * @param sentence  the melody sentence
    * @param profile   sentiment profile
@@ -37,26 +43,30 @@ public final class BackingTrackSelector {
     List<Note> melodyNotes = sentence.getAllNotes();
     long sentenceTotalTicks = (long) ppq * BEATS_PER_BAR * sentence.totalBars();
 
+    // One chord change per bar; minimum 4 slots so short sentences still vary.
+    int numSlots = Math.max(4, sentence.totalBars());
+
+    // Voicing chosen from sentiment — not through scoring — so that simple
+    // voicings (POWER) don't dominate the consonance calculation.
+    VoicingType voicing = selectVoicingBySentiment(profile);
+
     BackingTrack best = null;
     double bestScore = Double.NEGATIVE_INFINITY;
 
     for (HarmonyApproach approach : HarmonyApproach.values()) {
-      for (VoicingType voicing : VoicingType.values()) {
-        try {
-          BackingTrack candidate = evaluate(
-              sentence, profile, key, melodyNotes, approach, voicing, ppq,
-              tempoBpm, sentenceTotalTicks);
-          if (candidate.combinedScore() > bestScore) {
-            bestScore = candidate.combinedScore();
-            best = candidate;
-          }
-        } catch (Exception ignored) {
-          // Skip invalid combinations (e.g. voicing produces no playable notes)
+      try {
+        BackingTrack candidate = evaluate(
+            sentence, profile, key, melodyNotes, approach, voicing, ppq,
+            tempoBpm, sentenceTotalTicks, numSlots);
+        if (candidate.combinedScore() > bestScore) {
+          bestScore = candidate.combinedScore();
+          best = candidate;
         }
+      } catch (Exception ignored) {
+        // Skip invalid combinations (e.g. voicing produces no playable notes)
       }
     }
 
-    // Fallback: shouldn't happen, but guard against all-empty results
     if (best == null) {
       best = new BackingTrack(List.of(), BackingTrack.GUITAR_PROGRAM, 0.0);
     }
@@ -72,6 +82,30 @@ public final class BackingTrackSelector {
   // Private helpers
   // -----------------------------------------------------------------------
 
+  /**
+   * Maps a sentiment profile to an appropriate voicing type.
+   *
+   * <ul>
+   *   <li>TENSE / ANGRY (high arousal, low valence) → POWER</li>
+   *   <li>EXCITED (high arousal, positive valence) → BARRE</li>
+   *   <li>HAPPY (medium-high arousal, positive valence) → OPEN</li>
+   *   <li>CONTENT / medium energy → TRIAD</li>
+   *   <li>RELAXED / CONTENT (low arousal, positive) → JAZZ</li>
+   *   <li>SAD / GLOOMY (low valence) → SHELL</li>
+   * </ul>
+   */
+  private static VoicingType selectVoicingBySentiment(SentimentProfile profile) {
+    double arousal = profile.arousal();
+    double valence = profile.valence();
+    if (arousal >= 0.75 && valence < 0.4) return VoicingType.POWER;  // TENSE, ANGRY
+    if (arousal >= 0.75)                   return VoicingType.BARRE;  // EXCITED
+    if (arousal >= 0.5  && valence >= 0.6) return VoicingType.OPEN;   // HAPPY
+    if (arousal >= 0.5)                    return VoicingType.TRIAD;  // medium energy
+    if (valence >= 0.5)                    return VoicingType.JAZZ;   // RELAXED, CONTENT
+    if (valence < 0.35)                    return VoicingType.SHELL;  // SAD, GLOOMY
+    return VoicingType.OPEN;
+  }
+
   private static BackingTrack evaluate(
       Sentence sentence,
       SentimentProfile profile,
@@ -81,10 +115,12 @@ public final class BackingTrackSelector {
       VoicingType voicing,
       int ppq,
       int tempoBpm,
-      long sentenceTotalTicks) {
+      long sentenceTotalTicks,
+      int numSlots) {
 
     // 1. Generate chord slots aligned to declared phrase boundaries
-    List<ChordSlot> slots = approach.generateChords(melodyNotes, key, profile, sentenceTotalTicks);
+    List<ChordSlot> slots = approach.generateChords(
+        melodyNotes, key, profile, sentenceTotalTicks, numSlots);
 
     // 2. Plan rhythm density
     RhythmDensityPlan plan = RhythmDensityPlanner.plan(profile, "A", sentence);
@@ -113,8 +149,7 @@ public final class BackingTrackSelector {
    * Expands voiced chords + strum pattern into concrete {@link ChanneledNote} events.
    *
    * <p>For each voiced chord the strum pattern is applied relative to the chord's
-   * start tick; each active slot produces one set of note events (one per chord
-   * tone) with velocity scaled by slot position.
+   * start tick; the pattern loops for the full chord duration (one repeat per bar).
    */
   static List<ChanneledNote> buildChanneledNotes(
       List<VoicedChord> voiced, boolean[] strumPat, int ppq) {
@@ -168,7 +203,6 @@ public final class BackingTrackSelector {
     if (keyName == null || keyName.isBlank()) return KeySignature.major(0);
     String lower = keyName.toLowerCase();
     boolean minor = lower.contains("minor");
-    // Extract root note name (first token)
     String rootName = keyName.split("\\s+")[0];
     int root = noteNameToMidi(rootName);
     return minor ? KeySignature.minor(root) : KeySignature.major(root);

--- a/src/main/java/com/motifgen/guitar/backing/BackingTrackSelector.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingTrackSelector.java
@@ -1,0 +1,177 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Note;
+import com.motifgen.model.Sentence;
+import com.motifgen.sentiment.SentimentProfile;
+import com.motifgen.theory.KeySignature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Evaluates all combinations of {@link HarmonyApproach} (5) ×
+ * {@link VoicingType} (6) = 30 candidates and returns the {@link BackingTrack}
+ * with the highest combined score.
+ *
+ * <p>Combined score formula: {@code 0.5 × consonance + 0.5 × catchiness}.
+ */
+public final class BackingTrackSelector {
+
+  private static final int DEFAULT_PPQ   = 480;
+  private static final int DEFAULT_TEMPO = 120;
+
+  private BackingTrackSelector() {}
+
+  /**
+   * Selects the best backing track from all approach × voicing combinations.
+   *
+   * @param sentence the melody sentence
+   * @param profile  sentiment profile
+   * @return the highest-scoring {@link BackingTrack}
+   */
+  public static BackingTrack select(Sentence sentence, SentimentProfile profile) {
+    int ppq = ppqFromSentence(sentence);
+    KeySignature key = keyFromSentence(sentence);
+    List<Note> melodyNotes = sentence.getAllNotes();
+
+    BackingTrack best = null;
+    double bestScore = Double.NEGATIVE_INFINITY;
+
+    for (HarmonyApproach approach : HarmonyApproach.values()) {
+      for (VoicingType voicing : VoicingType.values()) {
+        try {
+          BackingTrack candidate = evaluate(
+              sentence, profile, key, melodyNotes, approach, voicing, ppq);
+          if (candidate.combinedScore() > bestScore) {
+            bestScore = candidate.combinedScore();
+            best = candidate;
+          }
+        } catch (Exception ignored) {
+          // Skip invalid combinations (e.g. voicing produces no playable notes)
+        }
+      }
+    }
+
+    // Fallback: shouldn't happen, but guard against all-empty results
+    if (best == null) {
+      best = new BackingTrack(List.of(), BackingTrack.GUITAR_PROGRAM, 0.0);
+    }
+    return best;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private static BackingTrack evaluate(
+      Sentence sentence,
+      SentimentProfile profile,
+      KeySignature key,
+      List<Note> melodyNotes,
+      HarmonyApproach approach,
+      VoicingType voicing,
+      int ppq) {
+
+    // 1. Generate chord slots
+    List<ChordSlot> slots = approach.generateChords(melodyNotes, key, profile);
+
+    // 2. Plan rhythm density
+    RhythmDensityPlan plan = RhythmDensityPlanner.plan(profile, "A", sentence);
+
+    // 3. Build strum pattern
+    boolean[] strumPat = StrumPattern.forSentiment(profile, voicing, DEFAULT_TEMPO, plan);
+
+    // 4. Voice chords
+    List<VoicedChord> voiced = GuitarChordVoicer.voice(slots, voicing, ppq);
+    if (voiced.isEmpty()) {
+      return new BackingTrack(List.of(), BackingTrack.GUITAR_PROGRAM, 0.0);
+    }
+
+    // 5. Score
+    double consonance = BackingConsonanceScorer.score(voiced, melodyNotes, ppq);
+    double catchiness  = BackingCatchinessScorer.score(sentence, voiced, strumPat, ppq);
+    double combined    = 0.5 * consonance + 0.5 * catchiness;
+
+    // 6. Build ChanneledNote list from voiced chords
+    List<ChanneledNote> channeledNotes = buildChanneledNotes(voiced, strumPat, ppq);
+
+    return new BackingTrack(channeledNotes, BackingTrack.GUITAR_PROGRAM, combined);
+  }
+
+  /**
+   * Expands voiced chords + strum pattern into concrete {@link ChanneledNote} events.
+   *
+   * <p>For each voiced chord the strum pattern is applied relative to the chord's
+   * start tick; each active slot produces one set of note events (one per chord
+   * tone) with velocity scaled by slot position.
+   */
+  static List<ChanneledNote> buildChanneledNotes(
+      List<VoicedChord> voiced, boolean[] strumPat, int ppq) {
+
+    List<ChanneledNote> result = new ArrayList<>();
+    if (voiced.isEmpty() || strumPat.length == 0) return result;
+
+    long slotTicks = (long) ppq / 2; // eighth-note grid
+    int patLen = strumPat.length;
+
+    for (VoicedChord vc : voiced) {
+      long chordStart = vc.startTick();
+      long chordEnd = vc.notes().isEmpty()
+          ? chordStart + ppq * 4L
+          : vc.notes().stream().mapToLong(Note::endTick).max().orElse(chordStart + ppq * 4L);
+      long chordDuration = chordEnd - chordStart;
+
+      for (int slot = 0; slot < patLen; slot++) {
+        if (!strumPat[slot]) continue;
+        long offsetTick = slot * slotTicks;
+        if (offsetTick >= chordDuration) break;
+        long noteTick = chordStart + offsetTick;
+        long noteDuration = Math.min(slotTicks, chordDuration - offsetTick);
+        int velocity = slot == 0 ? 80 : 64; // accent on beat 1
+
+        for (Note n : vc.notes()) {
+          if (n.isRest()) continue;
+          Note strumNote = new Note(n.pitch(), noteTick, noteDuration, velocity);
+          result.add(new ChanneledNote(strumNote, BackingTrack.BACKING_CHANNEL));
+        }
+      }
+    }
+    return result;
+  }
+
+  private static int ppqFromSentence(Sentence sentence) {
+    if (!sentence.getPhrases().isEmpty()) {
+      return sentence.getPhrases().getFirst().getTicksPerBeat();
+    }
+    return DEFAULT_PPQ;
+  }
+
+  private static KeySignature keyFromSentence(Sentence sentence) {
+    String keyName = sentence.getKeyName();
+    if (keyName == null || keyName.isBlank()) return KeySignature.major(0);
+    String lower = keyName.toLowerCase();
+    boolean minor = lower.contains("minor");
+    // Extract root note name (first token)
+    String rootName = keyName.split("\\s+")[0];
+    int root = noteNameToMidi(rootName);
+    return minor ? KeySignature.minor(root) : KeySignature.major(root);
+  }
+
+  private static int noteNameToMidi(String name) {
+    return switch (name.toUpperCase()) {
+      case "C"  -> 0;
+      case "C#", "DB" -> 1;
+      case "D"  -> 2;
+      case "D#", "EB" -> 3;
+      case "E"  -> 4;
+      case "F"  -> 5;
+      case "F#", "GB" -> 6;
+      case "G"  -> 7;
+      case "G#", "AB" -> 8;
+      case "A"  -> 9;
+      case "A#", "BB" -> 10;
+      case "B"  -> 11;
+      default   -> 0;
+    };
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/BackingTrackSelector.java
+++ b/src/main/java/com/motifgen/guitar/backing/BackingTrackSelector.java
@@ -19,20 +19,23 @@ public final class BackingTrackSelector {
 
   private static final int DEFAULT_PPQ   = 480;
   private static final int DEFAULT_TEMPO = 120;
+  private static final int BEATS_PER_BAR = 4;
 
   private BackingTrackSelector() {}
 
   /**
    * Selects the best backing track from all approach × voicing combinations.
    *
-   * @param sentence the melody sentence
-   * @param profile  sentiment profile
+   * @param sentence  the melody sentence
+   * @param profile   sentiment profile
+   * @param tempoBpm  playback tempo in BPM (used for strum-pattern tempo gating)
    * @return the highest-scoring {@link BackingTrack}
    */
-  public static BackingTrack select(Sentence sentence, SentimentProfile profile) {
+  public static BackingTrack select(Sentence sentence, SentimentProfile profile, int tempoBpm) {
     int ppq = ppqFromSentence(sentence);
     KeySignature key = keyFromSentence(sentence);
     List<Note> melodyNotes = sentence.getAllNotes();
+    long sentenceTotalTicks = (long) ppq * BEATS_PER_BAR * sentence.totalBars();
 
     BackingTrack best = null;
     double bestScore = Double.NEGATIVE_INFINITY;
@@ -41,7 +44,8 @@ public final class BackingTrackSelector {
       for (VoicingType voicing : VoicingType.values()) {
         try {
           BackingTrack candidate = evaluate(
-              sentence, profile, key, melodyNotes, approach, voicing, ppq);
+              sentence, profile, key, melodyNotes, approach, voicing, ppq,
+              tempoBpm, sentenceTotalTicks);
           if (candidate.combinedScore() > bestScore) {
             bestScore = candidate.combinedScore();
             best = candidate;
@@ -59,6 +63,11 @@ public final class BackingTrackSelector {
     return best;
   }
 
+  /** Backward-compatible overload defaulting to 120 BPM. */
+  public static BackingTrack select(Sentence sentence, SentimentProfile profile) {
+    return select(sentence, profile, DEFAULT_TEMPO);
+  }
+
   // -----------------------------------------------------------------------
   // Private helpers
   // -----------------------------------------------------------------------
@@ -70,16 +79,18 @@ public final class BackingTrackSelector {
       List<Note> melodyNotes,
       HarmonyApproach approach,
       VoicingType voicing,
-      int ppq) {
+      int ppq,
+      int tempoBpm,
+      long sentenceTotalTicks) {
 
-    // 1. Generate chord slots
-    List<ChordSlot> slots = approach.generateChords(melodyNotes, key, profile);
+    // 1. Generate chord slots aligned to declared phrase boundaries
+    List<ChordSlot> slots = approach.generateChords(melodyNotes, key, profile, sentenceTotalTicks);
 
     // 2. Plan rhythm density
     RhythmDensityPlan plan = RhythmDensityPlanner.plan(profile, "A", sentence);
 
-    // 3. Build strum pattern
-    boolean[] strumPat = StrumPattern.forSentiment(profile, voicing, DEFAULT_TEMPO, plan);
+    // 3. Build strum pattern using actual playback tempo
+    boolean[] strumPat = StrumPattern.forSentiment(profile, voicing, tempoBpm, plan);
 
     // 4. Voice chords
     List<VoicedChord> voiced = GuitarChordVoicer.voice(slots, voicing, ppq);
@@ -111,28 +122,34 @@ public final class BackingTrackSelector {
     List<ChanneledNote> result = new ArrayList<>();
     if (voiced.isEmpty() || strumPat.length == 0) return result;
 
-    long slotTicks = (long) ppq / 2; // eighth-note grid
+    long slotTicks = (long) ppq / 2; // eighth-note grid (one strum slot = one eighth note)
     int patLen = strumPat.length;
+    long patternDurationTicks = (long) patLen * slotTicks; // one bar worth of pattern
 
     for (VoicedChord vc : voiced) {
       long chordStart = vc.startTick();
-      long chordEnd = vc.notes().isEmpty()
-          ? chordStart + ppq * 4L
-          : vc.notes().stream().mapToLong(Note::endTick).max().orElse(chordStart + ppq * 4L);
-      long chordDuration = chordEnd - chordStart;
+      // Use the declared slot duration stored on the chord notes rather than endTick,
+      // so the pattern loops for the full chord span regardless of trailing-note offsets.
+      long chordDuration = vc.notes().isEmpty()
+          ? ppq * 4L
+          : vc.notes().get(0).durationTicks();
 
-      for (int slot = 0; slot < patLen; slot++) {
-        if (!strumPat[slot]) continue;
-        long offsetTick = slot * slotTicks;
-        if (offsetTick >= chordDuration) break;
-        long noteTick = chordStart + offsetTick;
-        long noteDuration = Math.min(slotTicks, chordDuration - offsetTick);
-        int velocity = slot == 0 ? 80 : 64; // accent on beat 1
+      // Repeat the strum pattern for the entire chord duration (one repeat per bar).
+      for (long barOffset = 0; barOffset < chordDuration; barOffset += patternDurationTicks) {
+        for (int slot = 0; slot < patLen; slot++) {
+          if (!strumPat[slot]) continue;
+          long offsetTick = barOffset + (long) slot * slotTicks;
+          if (offsetTick >= chordDuration) break;
+          long noteTick = chordStart + offsetTick;
+          long noteDuration = Math.min(slotTicks, chordDuration - offsetTick);
+          int velocity = slot == 0 ? 80 : 64; // accent beat 1 of every bar
 
-        for (Note n : vc.notes()) {
-          if (n.isRest()) continue;
-          Note strumNote = new Note(n.pitch(), noteTick, noteDuration, velocity);
-          result.add(new ChanneledNote(strumNote, BackingTrack.BACKING_CHANNEL));
+          for (Note n : vc.notes()) {
+            if (n.isRest()) continue;
+            result.add(new ChanneledNote(
+                new Note(n.pitch(), noteTick, noteDuration, velocity),
+                BackingTrack.BACKING_CHANNEL));
+          }
         }
       }
     }

--- a/src/main/java/com/motifgen/guitar/backing/ChanneledNote.java
+++ b/src/main/java/com/motifgen/guitar/backing/ChanneledNote.java
@@ -1,0 +1,13 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Note;
+
+/**
+ * A {@link Note} decorated with a MIDI channel index (0-indexed).
+ *
+ * <p>The backing track uses channel index 1 (= MIDI channel 2).
+ *
+ * @param note    the underlying note
+ * @param channel 0-indexed MIDI channel (0–15)
+ */
+public record ChanneledNote(Note note, int channel) {}

--- a/src/main/java/com/motifgen/guitar/backing/ChordSlot.java
+++ b/src/main/java/com/motifgen/guitar/backing/ChordSlot.java
@@ -1,0 +1,13 @@
+package com.motifgen.guitar.backing;
+
+import java.util.List;
+
+/**
+ * Holds the raw chord tones (MIDI pitch integers) for a single harmonic slot
+ * before voicing is applied.
+ *
+ * @param startTick     start position in MIDI ticks
+ * @param durationTicks length of this chord slot in ticks
+ * @param pitches       chord-tone MIDI pitches (unvoiced, may span multiple octaves)
+ */
+public record ChordSlot(long startTick, long durationTicks, List<Integer> pitches) {}

--- a/src/main/java/com/motifgen/guitar/backing/GuitarChordVoicer.java
+++ b/src/main/java/com/motifgen/guitar/backing/GuitarChordVoicer.java
@@ -1,0 +1,98 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.guitar.GuitarFingering;
+import com.motifgen.model.Note;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Voices {@link ChordSlot} objects into {@link VoicedChord} objects.
+ *
+ * <p>For each slot:
+ * <ol>
+ *   <li>Clamp each pitch to the guitar register MIDI 40–76 (E2–E5) by octave
+ *       transposition.</li>
+ *   <li>Deduplicate pitches within the register.</li>
+ *   <li>Pass the resulting notes through {@link GuitarFingering#compute} to
+ *       validate that fret positions exist (ensuring playability).</li>
+ *   <li>Return a {@link VoicedChord} whose {@code notes} carry the clamped
+ *       pitches, the slot duration, and a fixed velocity of 72.</li>
+ * </ol>
+ */
+public final class GuitarChordVoicer {
+
+  /** Lowest MIDI pitch in the guitar backing register (E2). */
+  public static final int MIN_PITCH = 40;
+
+  /** Highest MIDI pitch in the guitar backing register (E5). */
+  public static final int MAX_PITCH = 76;
+
+  private static final int DEFAULT_VELOCITY = 72;
+
+  private GuitarChordVoicer() {}
+
+  /**
+   * Voices a list of chord slots.
+   *
+   * @param slots    raw chord slots from a {@link HarmonyApproach}
+   * @param voicing  voicing type (affects pitch selection)
+   * @param ppq      ticks per quarter note (passed to GuitarFingering)
+   * @return list of voiced chords in slot order
+   */
+  public static List<VoicedChord> voice(List<ChordSlot> slots, VoicingType voicing, int ppq) {
+    List<VoicedChord> result = new ArrayList<>(slots.size());
+    for (ChordSlot slot : slots) {
+      result.add(voiceSlot(slot, voicing, ppq));
+    }
+    return result;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private static VoicedChord voiceSlot(ChordSlot slot, VoicingType voicing, int ppq) {
+    List<Integer> clamped = clampToRegister(slot.pitches(), voicing);
+
+    // Build Note objects for GuitarFingering validation
+    List<Note> chordNotes = new ArrayList<>();
+    for (int i = 0; i < clamped.size(); i++) {
+      chordNotes.add(new Note(clamped.get(i), slot.startTick() + (long) i, slot.durationTicks(),
+          DEFAULT_VELOCITY));
+    }
+
+    // Validate via GuitarFingering DP (ensures playable fret positions exist)
+    if (!chordNotes.isEmpty()) {
+      GuitarFingering.compute(chordNotes, ppq);
+    }
+
+    return new VoicedChord(slot.startTick(), chordNotes);
+  }
+
+  /** Clamps each pitch into MIDI 40–76 by octave transposition, then deduplicates. */
+  static List<Integer> clampToRegister(List<Integer> pitches, VoicingType voicing) {
+    List<Integer> result = new ArrayList<>();
+    for (int pitch : pitches) {
+      int clamped = clampByOctave(pitch);
+      if (!result.contains(clamped)) {
+        result.add(clamped);
+      }
+    }
+    // POWER voicing: keep only root and fifth (first two distinct pitches)
+    if (voicing == VoicingType.POWER && result.size() > 2) {
+      result = result.subList(0, 2);
+    }
+    // SHELL voicing: keep root, third, seventh (first, second, fourth if present)
+    if (voicing == VoicingType.SHELL && result.size() > 3) {
+      result = List.of(result.get(0), result.get(1), result.get(result.size() - 1));
+    }
+    return result;
+  }
+
+  private static int clampByOctave(int pitch) {
+    while (pitch < MIN_PITCH) pitch += 12;
+    while (pitch > MAX_PITCH) pitch -= 12;
+    return pitch;
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/GuitarChordVoicer.java
+++ b/src/main/java/com/motifgen/guitar/backing/GuitarChordVoicer.java
@@ -11,13 +11,13 @@ import java.util.List;
  *
  * <p>For each slot:
  * <ol>
- *   <li>Clamp each pitch to the guitar register MIDI 40–76 (E2–E5) by octave
- *       transposition.</li>
- *   <li>Deduplicate pitches within the register.</li>
- *   <li>Pass the resulting notes through {@link GuitarFingering#compute} to
- *       validate that fret positions exist (ensuring playability).</li>
- *   <li>Return a {@link VoicedChord} whose {@code notes} carry the clamped
- *       pitches, the slot duration, and a fixed velocity of 72.</li>
+ *   <li>Place the root (first pitch class in the slot) in the low-bass register
+ *       (MIDI 40–55, E2–G3) so the chord sounds grounded.</li>
+ *   <li>Stack each remaining chord tone strictly above the previous note,
+ *       yielding an ascending, root-position voicing within MIDI 40–76.</li>
+ *   <li>Apply voicing-type filters (POWER, SHELL) after stacking.</li>
+ *   <li>Pass the result through {@link GuitarFingering#compute} to validate
+ *       that fret positions exist (ensuring playability).</li>
  * </ol>
  */
 public final class GuitarChordVoicer {
@@ -27,6 +27,18 @@ public final class GuitarChordVoicer {
 
   /** Highest MIDI pitch in the guitar backing register (E5). */
   public static final int MAX_PITCH = 76;
+
+  /**
+   * Lowest root pitch for chord voicings (C3). Roots start here rather than at
+   * MIN_PITCH so chords sit in the C3–B4 range and stay close to the melody.
+   */
+  private static final int ROOT_FLOOR = 48;   // C3
+
+  /**
+   * Ceiling for chord root notes. Roots above this are dropped an octave so
+   * the chord has room to spread upward within the register.
+   */
+  private static final int ROOT_CEILING = 64; // E4
 
   private static final int DEFAULT_VELOCITY = 72;
 
@@ -53,16 +65,18 @@ public final class GuitarChordVoicer {
   // -----------------------------------------------------------------------
 
   private static VoicedChord voiceSlot(ChordSlot slot, VoicingType voicing, int ppq) {
-    List<Integer> clamped = clampToRegister(slot.pitches(), voicing);
+    List<Integer> pitched = buildAscendingVoicing(slot.pitches(), voicing);
 
     // Build Note objects for GuitarFingering validation
     List<Note> chordNotes = new ArrayList<>();
-    for (int i = 0; i < clamped.size(); i++) {
-      chordNotes.add(new Note(clamped.get(i), slot.startTick() + (long) i, slot.durationTicks(),
+    for (int i = 0; i < pitched.size(); i++) {
+      chordNotes.add(new Note(
+          pitched.get(i),
+          slot.startTick() + (long) i,
+          slot.durationTicks(),
           DEFAULT_VELOCITY));
     }
 
-    // Validate via GuitarFingering DP (ensures playable fret positions exist)
     if (!chordNotes.isEmpty()) {
       GuitarFingering.compute(chordNotes, ppq);
     }
@@ -70,29 +84,83 @@ public final class GuitarChordVoicer {
     return new VoicedChord(slot.startTick(), chordNotes);
   }
 
-  /** Clamps each pitch into MIDI 40–76 by octave transposition, then deduplicates. */
-  static List<Integer> clampToRegister(List<Integer> pitches, VoicingType voicing) {
+  /**
+   * Builds a standard guitar chord voicing from a list of pitch classes.
+   *
+   * <p>Uses real guitar chord shapes rather than mathematical stacking:
+   * <ul>
+   *   <li>BARRE → E-shape (6 strings) when root is low enough, A-shape (5) otherwise</li>
+   *   <li>OPEN  → A-shape (5 strings) or D-shape (4 strings) based on root height</li>
+   *   <li>TRIAD/JAZZ → D-shape (4 strings)</li>
+   *   <li>SHELL → compact 3-string open voicing (root + 3rd + 5th-above-octave)</li>
+   *   <li>POWER → root + fifth + octave (3 strings)</li>
+   * </ul>
+   *
+   * <p>Shape intervals follow standard barre/open chord patterns:
+   * E-shape [0,7,12,third,19,24], A-shape [0,7,12,third,19], D-shape [0,7,12,third]
+   * where {@code third} = 15 (minor) or 16 (major) above the root.
+   */
+  static List<Integer> buildAscendingVoicing(List<Integer> pitchClasses, VoicingType voicing) {
+    if (pitchClasses.isEmpty()) return List.of();
+
+    // Determine chord quality (major/minor) from the third pitch class
+    int rootPc = pitchClasses.get(0);
+    int thirdInterval = pitchClasses.size() >= 2
+        ? (pitchClasses.get(1) - rootPc + 12) % 12
+        : 4; // default major
+    int thirdLow  = thirdInterval;      // 3 (minor) or 4 (major) above root
+    int thirdHigh = 12 + thirdLow;     // same, one octave up: 15 (minor) or 16 (major)
+
+    // Place root in guitar bass register (C3–B3, MIDI 48–59)
+    int rootPitch = rootPc;
+    while (rootPitch < ROOT_FLOOR) rootPitch += 12;
+    while (rootPitch > MAX_PITCH)  rootPitch -= 12;
+    while (rootPitch > ROOT_CEILING && rootPitch - 12 >= ROOT_FLOOR) rootPitch -= 12;
+
+    // Select standard guitar chord shape intervals relative to root
+    int[] intervals = selectShapeIntervals(voicing, rootPitch, thirdLow, thirdHigh);
+
+    // Apply intervals; drop notes that fall outside the guitar register
     List<Integer> result = new ArrayList<>();
-    for (int pitch : pitches) {
-      int clamped = clampByOctave(pitch);
-      if (!result.contains(clamped)) {
-        result.add(clamped);
+    for (int interval : intervals) {
+      int pitch = rootPitch + interval;
+      if (pitch >= MIN_PITCH && pitch <= MAX_PITCH) {
+        result.add(pitch);
       }
     }
-    // POWER voicing: keep only root and fifth (first two distinct pitches)
-    if (voicing == VoicingType.POWER && result.size() > 2) {
-      result = result.subList(0, 2);
-    }
-    // SHELL voicing: keep root, third, seventh (first, second, fourth if present)
-    if (voicing == VoicingType.SHELL && result.size() > 3) {
-      result = List.of(result.get(0), result.get(1), result.get(result.size() - 1));
-    }
-    return result;
+    return result.isEmpty() ? List.of(rootPitch) : result;
   }
 
-  private static int clampByOctave(int pitch) {
-    while (pitch < MIN_PITCH) pitch += 12;
-    while (pitch > MAX_PITCH) pitch -= 12;
-    return pitch;
+  /**
+   * Returns the interval array (semitones above root) for a standard guitar chord shape.
+   *
+   * <p>Shape selection for BARRE and OPEN is based on how high the highest string would
+   * reach: E-shape adds 24 semitones above root (2 octaves), A-shape adds 19, D-shape
+   * adds {@code thirdHigh} (15 or 16). If the higher shape would exceed MAX_PITCH the
+   * next smaller shape is used automatically.
+   */
+  private static int[] selectShapeIntervals(
+      VoicingType voicing, int rootPitch, int thirdLow, int thirdHigh) {
+    return switch (voicing) {
+      case POWER -> new int[]{0, 7, 12};
+      case BARRE -> {
+        // E-shape (6 strings) if root+24 fits; A-shape (5) if root+19 fits; D-shape (4) otherwise
+        if (rootPitch + 24 <= MAX_PITCH) yield new int[]{0, 7, 12, thirdHigh, 19, 24};
+        if (rootPitch + 19 <= MAX_PITCH) yield new int[]{0, 7, 12, thirdHigh, 19};
+        yield new int[]{0, 7, 12, thirdHigh};
+      }
+      case OPEN -> {
+        // A-shape (5 strings) if root+19 fits; D-shape (4 strings) otherwise
+        if (rootPitch + 19 <= MAX_PITCH) yield new int[]{0, 7, 12, thirdHigh, 19};
+        yield new int[]{0, 7, 12, thirdHigh};
+      }
+      case SHELL -> new int[]{0, thirdLow, 19}; // root + 3rd (1st octave) + 5th (2nd octave)
+      default    -> new int[]{0, 7, 12, thirdHigh}; // TRIAD, JAZZ: D-shape (4 strings)
+    };
+  }
+
+  // Kept for test backward compatibility — delegates to buildAscendingVoicing
+  static List<Integer> clampToRegister(List<Integer> pitches, VoicingType voicing) {
+    return buildAscendingVoicing(pitches, voicing);
   }
 }

--- a/src/main/java/com/motifgen/guitar/backing/HarmonyApproach.java
+++ b/src/main/java/com/motifgen/guitar/backing/HarmonyApproach.java
@@ -10,200 +10,99 @@ import java.util.List;
 /**
  * The five harmony approaches available to the backing track generator.
  *
- * <p>Each variant implements
- * {@link #generateChords(List, KeySignature, SentimentProfile)} and returns a
- * list of {@link ChordSlot} objects covering the melodic timeline.
+ * <p>Each variant uses a well-known Roman-numeral chord progression
+ * (adapted for major or minor keys) so that the backing track sounds
+ * harmonically coherent and resolves correctly at phrase endings.
+ *
+ * <p>Scale-degree indices follow Java 0-based convention:
+ * 0=I/i, 1=II/ii, 2=III/iii, 3=IV/iv, 4=V/v, 5=VI/vi, 6=VII/vii
  */
 public enum HarmonyApproach {
 
   /**
-   * Diatonic triads (I ii iii IV V vi) assigned so their tones best contain the
-   * strong-beat melody note at each phrase boundary; ranked by voice-leading
-   * distance from the previous chord.
+   * Classical tonal harmony: selects from I, ii, IV, V using the strong-beat
+   * melody note to pick the chord containing it; forces V→I at every phrase cadence.
    */
   FUNCTIONAL_DIATONIC {
+    private static final int[] MAJ_PALETTE = {0, 1, 3, 4};  // I ii IV V
+    private static final int[] MIN_PALETTE = {0, 3, 4, 5};  // i iv v VI
+
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
-      if (melody.isEmpty()) return List.of();
-
-      long slotSize = computeSlotSize(declaredTotalTicks, 4);
-
-      // Build the 6 diatonic triads (I ii iii IV V vi) in the key
-      int[] scale = key.scaleDegrees();
-      int[][] triads = buildDiatonicTriads(scale);
-
-      List<ChordSlot> slots = new ArrayList<>();
-      List<Integer> prevChord = null;
-      for (int i = 0; i < 4; i++) {
-        long start = i * slotSize;
-        long end = Math.min(start + slotSize, declaredTotalTicks);
-        if (start >= declaredTotalTicks) break;
-
-        // Find the strong-beat melody note for this slot
-        final long slotStart = start;
-        final long slotEnd = end;
-        Note strongBeat = findStrongBeatNote(melody, slotStart, slotEnd);
-        int targetPc = strongBeat != null ? strongBeat.pitchClass() : key.root();
-
-        // Pick the triad that best contains the target pitch class, with
-        // tie-break by voice-leading distance from previous chord
-        int[] best = chooseBestTriad(triads, targetPc, prevChord);
-        List<Integer> pitches = triadToPitches(best);
-        slots.add(new ChordSlot(start, slotSize, pitches));
-        prevChord = pitches;
-      }
-      return slots;
+        List<Note> melody, KeySignature key, SentimentProfile sentiment,
+        long declaredTotalTicks, int numSlots) {
+      return generateMelodyAware(
+          key.minor() ? MIN_PALETTE : MAJ_PALETTE,
+          melody, key, declaredTotalTicks, numSlots);
     }
   },
 
   /**
-   * Builds triads on all 7 scale degrees of the melody's mode; picks the one
-   * with highest consonance with the melody note for each slot.
+   * Pop/rock palette: I, IV, V, vi — selects chord containing the strong-beat
+   * melody note; cadences with V→I at phrase boundaries.
    */
   MODAL_COLOUR {
+    private static final int[] MAJ_PALETTE = {0, 3, 4, 5};  // I IV V vi
+    private static final int[] MIN_PALETTE = {0, 3, 5, 6};  // i iv VI VII
+
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
-      if (melody.isEmpty()) return List.of();
-
-      long slotSize = computeSlotSize(declaredTotalTicks, 4);
-      int[] scale = key.scaleDegrees();
-      int[][] triads = buildDiatonicTriads(scale);
-
-      List<ChordSlot> slots = new ArrayList<>();
-      for (int i = 0; i < 4; i++) {
-        long start = i * slotSize;
-        if (start >= declaredTotalTicks) break;
-
-        final long slotStart = start;
-        final long slotEnd = Math.min(start + slotSize, declaredTotalTicks);
-        Note strongBeat = findStrongBeatNote(melody, slotStart, slotEnd);
-        int targetPc = strongBeat != null ? strongBeat.pitchClass() : key.root();
-
-        // Highest consonance = most overlap between triad tones and target pc
-        int[] best = triads[0];
-        int bestScore = -1;
-        for (int[] triad : triads) {
-          int score = consonanceScore(triad, targetPc);
-          if (score > bestScore) {
-            bestScore = score;
-            best = triad;
-          }
-        }
-        slots.add(new ChordSlot(start, slotSize, triadToPitches(best)));
-      }
-      return slots;
+        List<Note> melody, KeySignature key, SentimentProfile sentiment,
+        long declaredTotalTicks, int numSlots) {
+      return generateMelodyAware(
+          key.minor() ? MIN_PALETTE : MAJ_PALETTE,
+          melody, key, declaredTotalTicks, numSlots);
     }
   },
 
   /**
-   * Tonic chord repeated for all slots; quality = major/minor based on the key.
+   * Warm/steady palette: I, iii, IV, vi — adds the mediant for a richer colour;
+   * melody-driven chord selection with phrase cadences.
    */
   STATIC_PEDAL {
+    private static final int[] MAJ_PALETTE = {0, 2, 3, 5};  // I iii IV vi
+    private static final int[] MIN_PALETTE = {0, 2, 5, 6};  // i III VI VII
+
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
-      if (melody.isEmpty()) return List.of();
-
-      long slotSize = computeSlotSize(declaredTotalTicks, 4);
-
-      // Tonic triad: root, third (major=4 or minor=3 semitones), fifth
-      int root = key.root();
-      int third = key.minor() ? root + 3 : root + 4;
-      int fifth = root + 7;
-      List<Integer> tonic = List.of(root, third % 12, fifth % 12);
-
-      List<ChordSlot> slots = new ArrayList<>();
-      for (int i = 0; i < 4; i++) {
-        long start = i * slotSize;
-        if (start >= declaredTotalTicks) break;
-        slots.add(new ChordSlot(start, slotSize, tonic));
-      }
-      return slots;
+        List<Note> melody, KeySignature key, SentimentProfile sentiment,
+        long declaredTotalTicks, int numSlots) {
+      return generateMelodyAware(
+          key.minor() ? MIN_PALETTE : MAJ_PALETTE,
+          melody, key, declaredTotalTicks, numSlots);
     }
   },
 
   /**
-   * ii7-V7-I7 progression with shell voicings (root + third + seventh).
+   * Jazz palette: I, ii, V, vi — emphasises the ii–V relationship;
+   * melody-driven with ii→V→I cadential phrases.
    */
   JAZZ_SHELL {
+    private static final int[] MAJ_PALETTE = {0, 1, 4, 5};  // I ii V vi
+    private static final int[] MIN_PALETTE = {0, 1, 4, 5};  // i ii° v VI
+
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
-      if (melody.isEmpty()) return List.of();
-
-      long slotSize = computeSlotSize(declaredTotalTicks, 4);
-
-      int root = key.root();
-      // ii7: root+2, +(minor3rd), +(7th from ii root) = root+2, root+5, root+12
-      // V7: root+7, root+11, root+5 (shell: root, major3, minor7)
-      // I7 (or Imaj7): root, root+4, root+11 (major7)
-      List<List<Integer>> progression = List.of(
-          List.of((root + 2) % 12, (root + 5) % 12, (root + 0) % 12), // ii7 shell
-          List.of((root + 7) % 12, (root + 11) % 12, (root + 5) % 12), // V7 shell
-          List.of(root % 12, (root + 4) % 12, (root + 11) % 12),        // Imaj7 shell
-          List.of(root % 12, (root + 4) % 12, (root + 11) % 12)         // Imaj7 repeated
-      );
-
-      List<ChordSlot> slots = new ArrayList<>();
-      for (int i = 0; i < 4; i++) {
-        long start = i * slotSize;
-        if (start >= declaredTotalTicks) break;
-        slots.add(new ChordSlot(start, slotSize, progression.get(i)));
-      }
-      return slots;
+        List<Note> melody, KeySignature key, SentimentProfile sentiment,
+        long declaredTotalTicks, int numSlots) {
+      return generateMelodyAware(
+          key.minor() ? MIN_PALETTE : MAJ_PALETTE,
+          melody, key, declaredTotalTicks, numSlots);
     }
   },
 
   /**
-   * Matches the pitch-class set of each melody segment to the closest diatonic
-   * triad by overlap count.
+   * Blues/implied palette: all seven diatonic degrees — maximally flexible;
+   * selects the chord whose tones best match the melody at each bar.
    */
   IMPLIED_HARMONY {
+    private static final int[] ALL_PALETTE = {0, 1, 2, 3, 4, 5, 6};
+
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
-      if (melody.isEmpty()) return List.of();
-
-      long slotSize = computeSlotSize(declaredTotalTicks, 4);
-      int[] scale = key.scaleDegrees();
-      int[][] triads = buildDiatonicTriads(scale);
-
-      List<ChordSlot> slots = new ArrayList<>();
-      for (int i = 0; i < 4; i++) {
-        long start = i * slotSize;
-        if (start >= declaredTotalTicks) break;
-        final long slotStart = start;
-        final long slotEnd = Math.min(start + slotSize, declaredTotalTicks);
-
-        // Collect pitch classes in this segment
-        List<Integer> segmentPcs = melody.stream()
-            .filter(n -> !n.isRest()
-                && n.startTick() >= slotStart
-                && n.startTick() < slotEnd)
-            .map(Note::pitchClass)
-            .distinct()
-            .toList();
-
-        // Find the triad with most overlap
-        int[] best = triads[0];
-        int bestOverlap = -1;
-        for (int[] triad : triads) {
-          int overlap = 0;
-          for (int pc : segmentPcs) {
-            for (int t : triad) {
-              if (t == pc) overlap++;
-            }
-          }
-          if (overlap > bestOverlap) {
-            bestOverlap = overlap;
-            best = triad;
-          }
-        }
-        slots.add(new ChordSlot(start, slotSize, triadToPitches(best)));
-      }
-      return slots;
+        List<Note> melody, KeySignature key, SentimentProfile sentiment,
+        long declaredTotalTicks, int numSlots) {
+      return generateMelodyAware(ALL_PALETTE, melody, key, declaredTotalTicks, numSlots);
     }
   };
 
@@ -212,40 +111,70 @@ public enum HarmonyApproach {
   // -----------------------------------------------------------------------
 
   /**
-   * Generates chord slots covering the melodic timeline using the declared sentence duration.
+   * Generates chord slots covering the melodic timeline.
    *
    * @param melody              all melody notes in time order
    * @param key                 key signature of the piece
    * @param sentiment           sentiment profile (may influence chord quality)
-   * @param declaredTotalTicks  declared sentence duration (phrase count × bars × ticks-per-bar);
-   *                            use this instead of max(endTick) to keep slots on bar boundaries
+   * @param declaredTotalTicks  declared sentence duration (phrases × bars × ticks-per-bar)
+   * @param numSlots            number of chord slots to generate (controls harmonic rhythm)
    * @return list of chord slots, never null
    */
   public abstract List<ChordSlot> generateChords(
-      List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks);
+      List<Note> melody, KeySignature key, SentimentProfile sentiment,
+      long declaredTotalTicks, int numSlots);
 
   /**
-   * Backward-compatible 3-argument overload. Derives total ticks from the note list; prefer
-   * the 4-argument form when the declared sentence duration is available.
+   * Backward-compatible 4-argument overload. Uses 4 slots.
+   */
+  public final List<ChordSlot> generateChords(
+      List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
+    return generateChords(melody, key, sentiment, declaredTotalTicks, 4);
+  }
+
+  /**
+   * Backward-compatible 3-argument overload. Derives total ticks from the note list.
    */
   public final List<ChordSlot> generateChords(
       List<Note> melody, KeySignature key, SentimentProfile sentiment) {
     long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
-    return generateChords(melody, key, sentiment, totalTicks);
+    return generateChords(melody, key, sentiment, totalTicks, 4);
   }
 
   // -----------------------------------------------------------------------
   // Shared helpers (package-private for testability)
   // -----------------------------------------------------------------------
 
-  /** Divides the total melody tick span evenly into {@code count} slots. */
+  /**
+   * Generates chord slots from a Roman-numeral pattern (0-based scale-degree indices).
+   * The pattern cycles to fill {@code numSlots}.
+   */
+  static List<ChordSlot> generateFromPattern(
+      int[] scaleDegreePattern, KeySignature key,
+      long declaredTotalTicks, int numSlots) {
+
+    int[] scale = key.scaleDegrees();
+    int[][] triads = buildDiatonicTriads(scale);
+    long slotSize = computeSlotSize(declaredTotalTicks, numSlots);
+
+    List<ChordSlot> slots = new ArrayList<>();
+    for (int i = 0; i < numSlots; i++) {
+      long start = i * slotSize;
+      if (start >= declaredTotalTicks) break;
+      int degree = scaleDegreePattern[i % scaleDegreePattern.length];
+      slots.add(new ChordSlot(start, slotSize, triadToPitches(triads[degree])));
+    }
+    return slots;
+  }
+
+  /** Divides the total tick span evenly into {@code count} slots. */
   static long computeSlotSize(long totalTicks, int count) {
     return Math.max(1, totalTicks / count);
   }
 
   /**
    * Builds diatonic triads from the 7 scale degrees: each triad is
-   * [root_pc, third_pc, fifth_pc] (all mod 12).
+   * [root_pc, third_pc, fifth_pc] (pitch classes, all mod 12).
    */
   static int[][] buildDiatonicTriads(int[] scaleDegrees) {
     int[][] triads = new int[7][3];
@@ -263,72 +192,134 @@ public enum HarmonyApproach {
   }
 
   /**
-   * Finds the note closest to a strong beat (beat 0 of each bar, i.e. tick
-   * positions divisible by 4× ppq) within the given tick range.
-   * Falls back to the earliest note in the range.
+   * Melody-aware chord generator: for each slot selects the diatonic chord
+   * (from {@code palette}) whose tones best match the strong-beat melody note.
+   *
+   * <p>Cadence rule: the second-to-last slot of every 4-bar phrase is forced
+   * to the dominant (degree 4 = V/v), and the final slot to the tonic (degree 0 = I/i).
+   * This ensures every phrase resolves, regardless of the melody at those positions.
    */
-  static Note findStrongBeatNote(List<Note> melody, long start, long end) {
-    Note first = null;
-    for (Note n : melody) {
-      if (n.isRest()) continue;
-      if (n.startTick() >= start && n.startTick() < end) {
-        if (first == null) first = n;
-        // Treat any note as a candidate; just return the first non-rest
+  static List<ChordSlot> generateMelodyAware(
+      int[] palette, List<Note> melody, KeySignature key,
+      long declaredTotalTicks, int numSlots) {
+
+    int[] scale = key.scaleDegrees();
+    int[][] triads = buildDiatonicTriads(scale);
+    long slotSize = computeSlotSize(declaredTotalTicks, numSlots);
+    int slotsPerPhrase = 4;
+
+    List<ChordSlot> slots = new ArrayList<>();
+    int prevDegree = 0;
+
+    for (int i = 0; i < numSlots; i++) {
+      long start = i * slotSize;
+      if (start >= declaredTotalTicks) break;
+
+      int posInPhrase = i % slotsPerPhrase;
+      int degree;
+
+      Note strongBeat = findStrongBeatNote(melody, start, start + slotSize);
+      int targetPc = strongBeat != null ? ((strongBeat.pitch() % 12) + 12) % 12 : -1;
+
+      if (posInPhrase == slotsPerPhrase - 1) {
+        // Phrase final: tonic when melody fits, otherwise best melody-aware degree.
+        if (targetPc < 0 || chordContainsPc(triads[0], targetPc)) {
+          degree = 0;
+        } else {
+          degree = bestContainingDegree(triads, palette, targetPc, prevDegree);
+        }
+      } else if (posInPhrase == slotsPerPhrase - 2) {
+        // Pre-cadence: dominant when melody fits, otherwise best melody-aware degree.
+        if (targetPc < 0 || chordContainsPc(triads[4], targetPc)) {
+          degree = 4;
+        } else {
+          degree = bestContainingDegree(triads, palette, targetPc, prevDegree);
+        }
+      } else {
+        if (targetPc >= 0) {
+          degree = bestContainingDegree(triads, palette, targetPc, prevDegree);
+        } else {
+          degree = prevDegree;
+        }
+      }
+
+      slots.add(new ChordSlot(start, slotSize, triadToPitches(triads[degree])));
+      prevDegree = degree;
+    }
+    return slots;
+  }
+
+  /**
+   * Returns the degree from {@code palette} whose triad contains {@code targetPc}.
+   * Among containing chords, prefers the one closest to {@code prevDegree} for
+   * smooth voice-leading. Falls back to maximum consonance score if none contain it.
+   */
+  static int bestContainingDegree(int[][] triads, int[] palette, int targetPc, int prevDegree) {
+    int bestContaining = -1;
+    int bestDist = Integer.MAX_VALUE;
+    for (int d : palette) {
+      for (int pc : triads[d]) {
+        if (pc == targetPc) {
+          int dist = Math.abs(d - prevDegree);
+          if (dist < bestDist) {
+            bestDist = dist;
+            bestContaining = d;
+          }
+          break;
+        }
       }
     }
-    return first;
-  }
+    if (bestContaining >= 0) return bestContaining;
 
-  /**
-   * Counts how many of the triad's pitch classes equal the target pitch class,
-   * yielding a consonance score for MODAL_COLOUR selection.
-   */
-  static int consonanceScore(int[] triad, int targetPc) {
-    int score = 0;
-    for (int pc : triad) {
-      if (pc == targetPc) score += 2;       // direct match
-      else if ((Math.abs(pc - targetPc) % 12) == 5
-            || (Math.abs(pc - targetPc) % 12) == 7) score++; // 4th or 5th above
-    }
-    return score;
-  }
-
-  /**
-   * Chooses the best triad from the candidates by:
-   * <ol>
-   *   <li>Number of tones matching the target pitch class (higher = better)</li>
-   *   <li>Tie-break: minimum voice-leading distance from previous chord</li>
-   * </ol>
-   */
-  static int[] chooseBestTriad(int[][] triads, int targetPc, List<Integer> prevChord) {
-    int[] best = triads[0];
-    int bestContainment = -1;
-    int bestVoiceLeading = Integer.MAX_VALUE;
-
-    for (int[] triad : triads) {
-      int containment = consonanceScore(triad, targetPc);
-      int vl = prevChord == null ? 0 : voiceLeadingDistance(triad, prevChord);
-
-      if (containment > bestContainment
-          || (containment == bestContainment && vl < bestVoiceLeading)) {
-        bestContainment = containment;
-        bestVoiceLeading = vl;
-        best = triad;
+    // No chord contains the melody note exactly — pick by consonance score
+    int best = palette[0];
+    int bestScore = -1;
+    for (int d : palette) {
+      int score = consonanceScore(triads[d], targetPc);
+      if (score > bestScore) {
+        bestScore = score;
+        best = d;
       }
     }
     return best;
   }
 
-  /** Sum of minimum semitone distances between each new tone and the previous chord. */
-  private static int voiceLeadingDistance(int[] triad, List<Integer> prevChord) {
-    int total = 0;
-    for (int pc : triad) {
-      int minDist = prevChord.stream()
-          .mapToInt(p -> Math.min(Math.abs(pc - p), 12 - Math.abs(pc - p)))
-          .min()
-          .orElse(0);
-      total += minDist;
+  // Kept for tests that call the old helper methods
+  static Note findStrongBeatNote(List<Note> melody, long start, long end) {
+    for (Note n : melody) {
+      if (n.isRest()) continue;
+      if (n.startTick() >= start && n.startTick() < end) return n;
     }
-    return total;
+    return null;
+  }
+
+  static boolean chordContainsPc(int[] triad, int pc) {
+    for (int p : triad) {
+      if (p == pc) return true;
+    }
+    return false;
+  }
+
+  static int consonanceScore(int[] triad, int targetPc) {
+    int score = 0;
+    for (int pc : triad) {
+      if (pc == targetPc) score += 2;
+      else if ((Math.abs(pc - targetPc) % 12) == 5
+            || (Math.abs(pc - targetPc) % 12) == 7) score++;
+    }
+    return score;
+  }
+
+  static int[] chooseBestTriad(int[][] triads, int targetPc, List<Integer> prevChord) {
+    int[] best = triads[0];
+    int bestContainment = -1;
+    for (int[] triad : triads) {
+      int containment = consonanceScore(triad, targetPc);
+      if (containment > bestContainment) {
+        bestContainment = containment;
+        best = triad;
+      }
+    }
+    return best;
   }
 }

--- a/src/main/java/com/motifgen/guitar/backing/HarmonyApproach.java
+++ b/src/main/java/com/motifgen/guitar/backing/HarmonyApproach.java
@@ -24,11 +24,10 @@ public enum HarmonyApproach {
   FUNCTIONAL_DIATONIC {
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
       if (melody.isEmpty()) return List.of();
 
-      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
-      long slotSize = computeSlotSize(totalTicks, 4);
+      long slotSize = computeSlotSize(declaredTotalTicks, 4);
 
       // Build the 6 diatonic triads (I ii iii IV V vi) in the key
       int[] scale = key.scaleDegrees();
@@ -38,8 +37,8 @@ public enum HarmonyApproach {
       List<Integer> prevChord = null;
       for (int i = 0; i < 4; i++) {
         long start = i * slotSize;
-        long end = Math.min(start + slotSize, totalTicks);
-        if (start >= totalTicks) break;
+        long end = Math.min(start + slotSize, declaredTotalTicks);
+        if (start >= declaredTotalTicks) break;
 
         // Find the strong-beat melody note for this slot
         final long slotStart = start;
@@ -65,21 +64,20 @@ public enum HarmonyApproach {
   MODAL_COLOUR {
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
       if (melody.isEmpty()) return List.of();
 
-      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
-      long slotSize = computeSlotSize(totalTicks, 4);
+      long slotSize = computeSlotSize(declaredTotalTicks, 4);
       int[] scale = key.scaleDegrees();
       int[][] triads = buildDiatonicTriads(scale);
 
       List<ChordSlot> slots = new ArrayList<>();
       for (int i = 0; i < 4; i++) {
         long start = i * slotSize;
-        if (start >= totalTicks) break;
+        if (start >= declaredTotalTicks) break;
 
         final long slotStart = start;
-        final long slotEnd = Math.min(start + slotSize, totalTicks);
+        final long slotEnd = Math.min(start + slotSize, declaredTotalTicks);
         Note strongBeat = findStrongBeatNote(melody, slotStart, slotEnd);
         int targetPc = strongBeat != null ? strongBeat.pitchClass() : key.root();
 
@@ -105,11 +103,10 @@ public enum HarmonyApproach {
   STATIC_PEDAL {
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
       if (melody.isEmpty()) return List.of();
 
-      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
-      long slotSize = computeSlotSize(totalTicks, 4);
+      long slotSize = computeSlotSize(declaredTotalTicks, 4);
 
       // Tonic triad: root, third (major=4 or minor=3 semitones), fifth
       int root = key.root();
@@ -120,7 +117,7 @@ public enum HarmonyApproach {
       List<ChordSlot> slots = new ArrayList<>();
       for (int i = 0; i < 4; i++) {
         long start = i * slotSize;
-        if (start >= totalTicks) break;
+        if (start >= declaredTotalTicks) break;
         slots.add(new ChordSlot(start, slotSize, tonic));
       }
       return slots;
@@ -133,11 +130,10 @@ public enum HarmonyApproach {
   JAZZ_SHELL {
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
       if (melody.isEmpty()) return List.of();
 
-      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
-      long slotSize = computeSlotSize(totalTicks, 4);
+      long slotSize = computeSlotSize(declaredTotalTicks, 4);
 
       int root = key.root();
       // ii7: root+2, +(minor3rd), +(7th from ii root) = root+2, root+5, root+12
@@ -153,7 +149,7 @@ public enum HarmonyApproach {
       List<ChordSlot> slots = new ArrayList<>();
       for (int i = 0; i < 4; i++) {
         long start = i * slotSize;
-        if (start >= totalTicks) break;
+        if (start >= declaredTotalTicks) break;
         slots.add(new ChordSlot(start, slotSize, progression.get(i)));
       }
       return slots;
@@ -167,20 +163,19 @@ public enum HarmonyApproach {
   IMPLIED_HARMONY {
     @Override
     public List<ChordSlot> generateChords(
-        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+        List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks) {
       if (melody.isEmpty()) return List.of();
 
-      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
-      long slotSize = computeSlotSize(totalTicks, 4);
+      long slotSize = computeSlotSize(declaredTotalTicks, 4);
       int[] scale = key.scaleDegrees();
       int[][] triads = buildDiatonicTriads(scale);
 
       List<ChordSlot> slots = new ArrayList<>();
       for (int i = 0; i < 4; i++) {
         long start = i * slotSize;
-        if (start >= totalTicks) break;
+        if (start >= declaredTotalTicks) break;
         final long slotStart = start;
-        final long slotEnd = Math.min(start + slotSize, totalTicks);
+        final long slotEnd = Math.min(start + slotSize, declaredTotalTicks);
 
         // Collect pitch classes in this segment
         List<Integer> segmentPcs = melody.stream()
@@ -217,15 +212,27 @@ public enum HarmonyApproach {
   // -----------------------------------------------------------------------
 
   /**
-   * Generates chord slots covering the melodic timeline.
+   * Generates chord slots covering the melodic timeline using the declared sentence duration.
    *
-   * @param melody    all melody notes in time order
-   * @param key       key signature of the piece
-   * @param sentiment sentiment profile (may influence chord quality)
+   * @param melody              all melody notes in time order
+   * @param key                 key signature of the piece
+   * @param sentiment           sentiment profile (may influence chord quality)
+   * @param declaredTotalTicks  declared sentence duration (phrase count × bars × ticks-per-bar);
+   *                            use this instead of max(endTick) to keep slots on bar boundaries
    * @return list of chord slots, never null
    */
   public abstract List<ChordSlot> generateChords(
-      List<Note> melody, KeySignature key, SentimentProfile sentiment);
+      List<Note> melody, KeySignature key, SentimentProfile sentiment, long declaredTotalTicks);
+
+  /**
+   * Backward-compatible 3-argument overload. Derives total ticks from the note list; prefer
+   * the 4-argument form when the declared sentence duration is available.
+   */
+  public final List<ChordSlot> generateChords(
+      List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+    long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
+    return generateChords(melody, key, sentiment, totalTicks);
+  }
 
   // -----------------------------------------------------------------------
   // Shared helpers (package-private for testability)

--- a/src/main/java/com/motifgen/guitar/backing/HarmonyApproach.java
+++ b/src/main/java/com/motifgen/guitar/backing/HarmonyApproach.java
@@ -1,0 +1,327 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Note;
+import com.motifgen.sentiment.SentimentProfile;
+import com.motifgen.theory.KeySignature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The five harmony approaches available to the backing track generator.
+ *
+ * <p>Each variant implements
+ * {@link #generateChords(List, KeySignature, SentimentProfile)} and returns a
+ * list of {@link ChordSlot} objects covering the melodic timeline.
+ */
+public enum HarmonyApproach {
+
+  /**
+   * Diatonic triads (I ii iii IV V vi) assigned so their tones best contain the
+   * strong-beat melody note at each phrase boundary; ranked by voice-leading
+   * distance from the previous chord.
+   */
+  FUNCTIONAL_DIATONIC {
+    @Override
+    public List<ChordSlot> generateChords(
+        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+      if (melody.isEmpty()) return List.of();
+
+      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
+      long slotSize = computeSlotSize(totalTicks, 4);
+
+      // Build the 6 diatonic triads (I ii iii IV V vi) in the key
+      int[] scale = key.scaleDegrees();
+      int[][] triads = buildDiatonicTriads(scale);
+
+      List<ChordSlot> slots = new ArrayList<>();
+      List<Integer> prevChord = null;
+      for (int i = 0; i < 4; i++) {
+        long start = i * slotSize;
+        long end = Math.min(start + slotSize, totalTicks);
+        if (start >= totalTicks) break;
+
+        // Find the strong-beat melody note for this slot
+        final long slotStart = start;
+        final long slotEnd = end;
+        Note strongBeat = findStrongBeatNote(melody, slotStart, slotEnd);
+        int targetPc = strongBeat != null ? strongBeat.pitchClass() : key.root();
+
+        // Pick the triad that best contains the target pitch class, with
+        // tie-break by voice-leading distance from previous chord
+        int[] best = chooseBestTriad(triads, targetPc, prevChord);
+        List<Integer> pitches = triadToPitches(best);
+        slots.add(new ChordSlot(start, slotSize, pitches));
+        prevChord = pitches;
+      }
+      return slots;
+    }
+  },
+
+  /**
+   * Builds triads on all 7 scale degrees of the melody's mode; picks the one
+   * with highest consonance with the melody note for each slot.
+   */
+  MODAL_COLOUR {
+    @Override
+    public List<ChordSlot> generateChords(
+        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+      if (melody.isEmpty()) return List.of();
+
+      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
+      long slotSize = computeSlotSize(totalTicks, 4);
+      int[] scale = key.scaleDegrees();
+      int[][] triads = buildDiatonicTriads(scale);
+
+      List<ChordSlot> slots = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+        long start = i * slotSize;
+        if (start >= totalTicks) break;
+
+        final long slotStart = start;
+        final long slotEnd = Math.min(start + slotSize, totalTicks);
+        Note strongBeat = findStrongBeatNote(melody, slotStart, slotEnd);
+        int targetPc = strongBeat != null ? strongBeat.pitchClass() : key.root();
+
+        // Highest consonance = most overlap between triad tones and target pc
+        int[] best = triads[0];
+        int bestScore = -1;
+        for (int[] triad : triads) {
+          int score = consonanceScore(triad, targetPc);
+          if (score > bestScore) {
+            bestScore = score;
+            best = triad;
+          }
+        }
+        slots.add(new ChordSlot(start, slotSize, triadToPitches(best)));
+      }
+      return slots;
+    }
+  },
+
+  /**
+   * Tonic chord repeated for all slots; quality = major/minor based on the key.
+   */
+  STATIC_PEDAL {
+    @Override
+    public List<ChordSlot> generateChords(
+        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+      if (melody.isEmpty()) return List.of();
+
+      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
+      long slotSize = computeSlotSize(totalTicks, 4);
+
+      // Tonic triad: root, third (major=4 or minor=3 semitones), fifth
+      int root = key.root();
+      int third = key.minor() ? root + 3 : root + 4;
+      int fifth = root + 7;
+      List<Integer> tonic = List.of(root, third % 12, fifth % 12);
+
+      List<ChordSlot> slots = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+        long start = i * slotSize;
+        if (start >= totalTicks) break;
+        slots.add(new ChordSlot(start, slotSize, tonic));
+      }
+      return slots;
+    }
+  },
+
+  /**
+   * ii7-V7-I7 progression with shell voicings (root + third + seventh).
+   */
+  JAZZ_SHELL {
+    @Override
+    public List<ChordSlot> generateChords(
+        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+      if (melody.isEmpty()) return List.of();
+
+      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
+      long slotSize = computeSlotSize(totalTicks, 4);
+
+      int root = key.root();
+      // ii7: root+2, +(minor3rd), +(7th from ii root) = root+2, root+5, root+12
+      // V7: root+7, root+11, root+5 (shell: root, major3, minor7)
+      // I7 (or Imaj7): root, root+4, root+11 (major7)
+      List<List<Integer>> progression = List.of(
+          List.of((root + 2) % 12, (root + 5) % 12, (root + 0) % 12), // ii7 shell
+          List.of((root + 7) % 12, (root + 11) % 12, (root + 5) % 12), // V7 shell
+          List.of(root % 12, (root + 4) % 12, (root + 11) % 12),        // Imaj7 shell
+          List.of(root % 12, (root + 4) % 12, (root + 11) % 12)         // Imaj7 repeated
+      );
+
+      List<ChordSlot> slots = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+        long start = i * slotSize;
+        if (start >= totalTicks) break;
+        slots.add(new ChordSlot(start, slotSize, progression.get(i)));
+      }
+      return slots;
+    }
+  },
+
+  /**
+   * Matches the pitch-class set of each melody segment to the closest diatonic
+   * triad by overlap count.
+   */
+  IMPLIED_HARMONY {
+    @Override
+    public List<ChordSlot> generateChords(
+        List<Note> melody, KeySignature key, SentimentProfile sentiment) {
+      if (melody.isEmpty()) return List.of();
+
+      long totalTicks = melody.stream().mapToLong(Note::endTick).max().orElse(0);
+      long slotSize = computeSlotSize(totalTicks, 4);
+      int[] scale = key.scaleDegrees();
+      int[][] triads = buildDiatonicTriads(scale);
+
+      List<ChordSlot> slots = new ArrayList<>();
+      for (int i = 0; i < 4; i++) {
+        long start = i * slotSize;
+        if (start >= totalTicks) break;
+        final long slotStart = start;
+        final long slotEnd = Math.min(start + slotSize, totalTicks);
+
+        // Collect pitch classes in this segment
+        List<Integer> segmentPcs = melody.stream()
+            .filter(n -> !n.isRest()
+                && n.startTick() >= slotStart
+                && n.startTick() < slotEnd)
+            .map(Note::pitchClass)
+            .distinct()
+            .toList();
+
+        // Find the triad with most overlap
+        int[] best = triads[0];
+        int bestOverlap = -1;
+        for (int[] triad : triads) {
+          int overlap = 0;
+          for (int pc : segmentPcs) {
+            for (int t : triad) {
+              if (t == pc) overlap++;
+            }
+          }
+          if (overlap > bestOverlap) {
+            bestOverlap = overlap;
+            best = triad;
+          }
+        }
+        slots.add(new ChordSlot(start, slotSize, triadToPitches(best)));
+      }
+      return slots;
+    }
+  };
+
+  // -----------------------------------------------------------------------
+  // Abstract method
+  // -----------------------------------------------------------------------
+
+  /**
+   * Generates chord slots covering the melodic timeline.
+   *
+   * @param melody    all melody notes in time order
+   * @param key       key signature of the piece
+   * @param sentiment sentiment profile (may influence chord quality)
+   * @return list of chord slots, never null
+   */
+  public abstract List<ChordSlot> generateChords(
+      List<Note> melody, KeySignature key, SentimentProfile sentiment);
+
+  // -----------------------------------------------------------------------
+  // Shared helpers (package-private for testability)
+  // -----------------------------------------------------------------------
+
+  /** Divides the total melody tick span evenly into {@code count} slots. */
+  static long computeSlotSize(long totalTicks, int count) {
+    return Math.max(1, totalTicks / count);
+  }
+
+  /**
+   * Builds diatonic triads from the 7 scale degrees: each triad is
+   * [root_pc, third_pc, fifth_pc] (all mod 12).
+   */
+  static int[][] buildDiatonicTriads(int[] scaleDegrees) {
+    int[][] triads = new int[7][3];
+    for (int i = 0; i < 7; i++) {
+      triads[i][0] = scaleDegrees[i];
+      triads[i][1] = scaleDegrees[(i + 2) % 7];
+      triads[i][2] = scaleDegrees[(i + 4) % 7];
+    }
+    return triads;
+  }
+
+  /** Converts a pitch-class triad to a List of pitch-class integers. */
+  static List<Integer> triadToPitches(int[] triad) {
+    return List.of(triad[0], triad[1], triad[2]);
+  }
+
+  /**
+   * Finds the note closest to a strong beat (beat 0 of each bar, i.e. tick
+   * positions divisible by 4× ppq) within the given tick range.
+   * Falls back to the earliest note in the range.
+   */
+  static Note findStrongBeatNote(List<Note> melody, long start, long end) {
+    Note first = null;
+    for (Note n : melody) {
+      if (n.isRest()) continue;
+      if (n.startTick() >= start && n.startTick() < end) {
+        if (first == null) first = n;
+        // Treat any note as a candidate; just return the first non-rest
+      }
+    }
+    return first;
+  }
+
+  /**
+   * Counts how many of the triad's pitch classes equal the target pitch class,
+   * yielding a consonance score for MODAL_COLOUR selection.
+   */
+  static int consonanceScore(int[] triad, int targetPc) {
+    int score = 0;
+    for (int pc : triad) {
+      if (pc == targetPc) score += 2;       // direct match
+      else if ((Math.abs(pc - targetPc) % 12) == 5
+            || (Math.abs(pc - targetPc) % 12) == 7) score++; // 4th or 5th above
+    }
+    return score;
+  }
+
+  /**
+   * Chooses the best triad from the candidates by:
+   * <ol>
+   *   <li>Number of tones matching the target pitch class (higher = better)</li>
+   *   <li>Tie-break: minimum voice-leading distance from previous chord</li>
+   * </ol>
+   */
+  static int[] chooseBestTriad(int[][] triads, int targetPc, List<Integer> prevChord) {
+    int[] best = triads[0];
+    int bestContainment = -1;
+    int bestVoiceLeading = Integer.MAX_VALUE;
+
+    for (int[] triad : triads) {
+      int containment = consonanceScore(triad, targetPc);
+      int vl = prevChord == null ? 0 : voiceLeadingDistance(triad, prevChord);
+
+      if (containment > bestContainment
+          || (containment == bestContainment && vl < bestVoiceLeading)) {
+        bestContainment = containment;
+        bestVoiceLeading = vl;
+        best = triad;
+      }
+    }
+    return best;
+  }
+
+  /** Sum of minimum semitone distances between each new tone and the previous chord. */
+  private static int voiceLeadingDistance(int[] triad, List<Integer> prevChord) {
+    int total = 0;
+    for (int pc : triad) {
+      int minDist = prevChord.stream()
+          .mapToInt(p -> Math.min(Math.abs(pc - p), 12 - Math.abs(pc - p)))
+          .min()
+          .orElse(0);
+      total += minDist;
+    }
+    return total;
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/RhythmDensityPlan.java
+++ b/src/main/java/com/motifgen/guitar/backing/RhythmDensityPlan.java
@@ -1,0 +1,17 @@
+package com.motifgen.guitar.backing;
+
+import java.util.List;
+
+/**
+ * Output of the {@link RhythmDensityPlanner}: the chosen subdivision level,
+ * how many chord changes occur per bar, and which beat positions (0-indexed)
+ * carry a rhythmic accent.
+ *
+ * @param subdivision   target rhythmic granularity
+ * @param changesPerBar number of chord changes per bar (1, 2, or 4)
+ * @param accentBeats   0-indexed beat positions that receive an accent within one bar
+ */
+public record RhythmDensityPlan(
+    Subdivision subdivision,
+    int changesPerBar,
+    List<Integer> accentBeats) {}

--- a/src/main/java/com/motifgen/guitar/backing/RhythmDensityPlanner.java
+++ b/src/main/java/com/motifgen/guitar/backing/RhythmDensityPlanner.java
@@ -1,0 +1,129 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Sentence;
+import com.motifgen.sentiment.SentimentProfile;
+
+import java.util.List;
+
+/**
+ * Maps a {@link SentimentProfile} + section name to a {@link RhythmDensityPlan}.
+ *
+ * <h3>Arousal → subdivision</h3>
+ * <pre>
+ *   0.000 – 0.250  → WHOLE
+ *   0.250 – 0.500  → HALF
+ *   0.500 – 0.750  → QUARTER
+ *   0.750 – 0.875  → EIGHTH
+ *   0.875 – 1.000  → SIXTEENTH
+ * </pre>
+ *
+ * <h3>Section multipliers</h3>
+ * <pre>
+ *   A      → 1.0  (baseline)
+ *   B      → 1.3  (denser)
+ *   INTRO  → 0.7  (sparser)
+ *   OUTRO  → 0.6  (sparsest)
+ * </pre>
+ *
+ * <h3>Melody-density complementarity</h3>
+ * If melody density (non-rest notes / total bars) &gt; 0.7 and the chosen
+ * subdivision is EIGHTH or finer, the planner steps it down one level.
+ */
+public final class RhythmDensityPlanner {
+
+  private static final double THRESHOLD_HALF       = 0.25;
+  private static final double THRESHOLD_QUARTER     = 0.50;
+  private static final double THRESHOLD_EIGHTH      = 0.75;
+  private static final double THRESHOLD_SIXTEENTH   = 0.875;
+
+  private static final double MULTIPLIER_B     = 1.3;
+  private static final double MULTIPLIER_A     = 1.0;
+  private static final double MULTIPLIER_INTRO = 0.7;
+  private static final double MULTIPLIER_OUTRO = 0.6;
+
+  private static final double MELODY_DENSITY_THRESHOLD = 0.7;
+
+  private RhythmDensityPlanner() {}
+
+  /**
+   * Produces a {@link RhythmDensityPlan} for the given inputs.
+   *
+   * @param profile  sentiment profile supplying arousal
+   * @param section  section label (A, B, INTRO, OUTRO; anything else treated as A)
+   * @param sentence the melody sentence (used to compute melody density)
+   * @return computed plan
+   */
+  public static RhythmDensityPlan plan(
+      SentimentProfile profile, String section, Sentence sentence) {
+
+    double arousal = profile.arousal();
+    double multiplier = sectionMultiplier(section);
+
+    // Effective arousal adjusted by section multiplier (clamped to [0,1])
+    double effectiveArousal = Math.min(1.0, Math.max(0.0, arousal * multiplier));
+
+    Subdivision subdivision = arousalToSubdivision(effectiveArousal);
+
+    // Melody-density complementarity
+    double melodyDensity = computeMelodyDensity(sentence);
+    if (melodyDensity > MELODY_DENSITY_THRESHOLD
+        && subdivision.ordinal() >= Subdivision.EIGHTH.ordinal()) {
+      subdivision = subdivision.stepDown();
+    }
+
+    int changesPerBar = changesPerBar(subdivision);
+    List<Integer> accents = accentBeats(subdivision);
+
+    return new RhythmDensityPlan(subdivision, changesPerBar, accents);
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private static Subdivision arousalToSubdivision(double arousal) {
+    if (arousal < THRESHOLD_HALF)     return Subdivision.WHOLE;
+    if (arousal < THRESHOLD_QUARTER)  return Subdivision.HALF;
+    if (arousal < THRESHOLD_EIGHTH)   return Subdivision.QUARTER;
+    if (arousal < THRESHOLD_SIXTEENTH) return Subdivision.EIGHTH;
+    return Subdivision.SIXTEENTH;
+  }
+
+  private static double sectionMultiplier(String section) {
+    if (section == null) return MULTIPLIER_A;
+    return switch (section.toUpperCase()) {
+      case "B"     -> MULTIPLIER_B;
+      case "INTRO" -> MULTIPLIER_INTRO;
+      case "OUTRO" -> MULTIPLIER_OUTRO;
+      default      -> MULTIPLIER_A;
+    };
+  }
+
+  private static double computeMelodyDensity(Sentence sentence) {
+    int totalBars = Math.max(1, sentence.totalBars());
+    long noteCount = sentence.getAllNotes().stream()
+        .filter(n -> !n.isRest())
+        .count();
+    return (double) noteCount / totalBars;
+  }
+
+  private static int changesPerBar(Subdivision subdivision) {
+    return switch (subdivision) {
+      case WHOLE     -> 1;
+      case HALF      -> 1;
+      case QUARTER   -> 2;
+      case EIGHTH    -> 4;
+      case SIXTEENTH -> 4;
+    };
+  }
+
+  private static List<Integer> accentBeats(Subdivision subdivision) {
+    return switch (subdivision) {
+      case WHOLE     -> List.of(0);
+      case HALF      -> List.of(0, 2);
+      case QUARTER   -> List.of(0, 2);
+      case EIGHTH    -> List.of(0, 2, 4, 6);
+      case SIXTEENTH -> List.of(0, 4, 8, 12);
+    };
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/StrumPattern.java
+++ b/src/main/java/com/motifgen/guitar/backing/StrumPattern.java
@@ -1,0 +1,161 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.sentiment.SentimentProfile;
+
+import java.util.Arrays;
+
+/**
+ * Factory for strum-pattern boolean arrays (true = strum, false = rest).
+ *
+ * <p>Seven built-in archetypes are provided. The {@link #forSentiment} factory
+ * applies valence-driven up/down adjustments, tempo gating, voicing-type
+ * filters, and POWER-mode bias.
+ */
+public final class StrumPattern {
+
+  /** The seven named strum archetypes. */
+  public enum Archetype {
+    DRIVING,
+    FOLK,
+    FUNK,
+    BALLAD,
+    REGGAE,
+    POWER,
+    ARPEGGIO
+  }
+
+  // Eight-slot (one bar of eighth notes at 4/4) base patterns per archetype.
+  // true = strum on that eighth-note slot, false = rest.
+  private static final boolean[] PATTERN_DRIVING  = {true,  true,  true,  true,  true,  true,  true,  true};
+  private static final boolean[] PATTERN_FOLK      = {true,  false, true,  false, true,  true,  false, true};
+  private static final boolean[] PATTERN_FUNK      = {true,  false, false, true,  false, true,  false, false};
+  private static final boolean[] PATTERN_BALLAD    = {true,  false, false, false, true,  false, false, false};
+  private static final boolean[] PATTERN_REGGAE    = {false, false, true,  false, false, false, true,  false};
+  private static final boolean[] PATTERN_POWER     = {true,  false, false, false, true,  false, false, false};
+  private static final boolean[] PATTERN_ARPEGGIO  = {true,  false, true,  false, true,  false, true,  false};
+
+  private static final double VALENCE_UPSTROKE_THRESHOLD = 0.6;
+  private static final int    TEMPO_SIMPLIFY_THRESHOLD   = 160;
+
+  private StrumPattern() {}
+
+  /**
+   * Returns a copy of the base pattern for the given archetype.
+   *
+   * @param archetype one of the seven named archetypes
+   * @return copy of the eight-slot boolean array
+   */
+  public static boolean[] forArchetype(Archetype archetype) {
+    boolean[] base = switch (archetype) {
+      case DRIVING  -> PATTERN_DRIVING;
+      case FOLK     -> PATTERN_FOLK;
+      case FUNK     -> PATTERN_FUNK;
+      case BALLAD   -> PATTERN_BALLAD;
+      case REGGAE   -> PATTERN_REGGAE;
+      case POWER    -> PATTERN_POWER;
+      case ARPEGGIO -> PATTERN_ARPEGGIO;
+    };
+    return Arrays.copyOf(base, base.length);
+  }
+
+  /**
+   * Chooses and modifies a strum pattern based on sentiment, voicing type, tempo,
+   * and the rhythm density plan.
+   *
+   * <ul>
+   *   <li>Archetype selected from {@link #pickArchetype(SentimentProfile, VoicingType)}</li>
+   *   <li>Valence &gt; 0.6 flips some downstrokes (even slots) to upstrokes (odd slots on)</li>
+   *   <li>Tempo &gt; 160 BPM + SIXTEENTH subdivision → simplified to EIGHTH (length ≤ 8)</li>
+   *   <li>JAZZ voicing → remove every other strum (reduce density)</li>
+   *   <li>POWER voicing → ensure beats 0 and 4 are always strummed</li>
+   * </ul>
+   *
+   * @param profile   sentiment profile
+   * @param voicing   voicing type
+   * @param tempoBpm  tempo in BPM
+   * @param plan      rhythm density plan from the planner
+   * @return modified strum pattern array
+   */
+  public static boolean[] forSentiment(
+      SentimentProfile profile, VoicingType voicing, int tempoBpm, RhythmDensityPlan plan) {
+
+    Archetype archetype = pickArchetype(profile, voicing);
+    boolean[] pattern = forArchetype(archetype);
+
+    // Tempo gate: if tempo > 160 and subdivision is SIXTEENTH, simplify to EIGHTH length
+    if (tempoBpm > TEMPO_SIMPLIFY_THRESHOLD && plan.subdivision() == Subdivision.SIXTEENTH) {
+      pattern = toEighthLength(pattern);
+    }
+
+    // Valence adjustment: high valence flips some even-indexed downstrokes to upstrokes
+    if (profile.valence() > VALENCE_UPSTROKE_THRESHOLD) {
+      pattern = applyUpstrokes(pattern);
+    }
+
+    // JAZZ: remove every other active strum (mute + reduce density)
+    if (voicing == VoicingType.JAZZ) {
+      pattern = jazzFilter(pattern);
+    }
+
+    // POWER: ensure beats 0 and 4 are always strummed
+    if (voicing == VoicingType.POWER) {
+      if (pattern.length > 0) pattern[0] = true;
+      if (pattern.length > 4) pattern[4] = true;
+    }
+
+    return pattern;
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  private static Archetype pickArchetype(SentimentProfile profile, VoicingType voicing) {
+    if (voicing == VoicingType.JAZZ || voicing == VoicingType.SHELL) return Archetype.ARPEGGIO;
+    if (voicing == VoicingType.POWER) return Archetype.POWER;
+
+    double valence = profile.valence();
+    double arousal = profile.arousal();
+
+    if (arousal > 0.75) return valence > 0.5 ? Archetype.DRIVING : Archetype.FUNK;
+    if (arousal > 0.5)  return valence > 0.5 ? Archetype.FOLK    : Archetype.REGGAE;
+    return Archetype.BALLAD;
+  }
+
+  /** Collapses a 16-slot pattern to 8 slots by OR-ing each pair. */
+  private static boolean[] toEighthLength(boolean[] src) {
+    if (src.length <= 8) return Arrays.copyOf(src, src.length);
+    boolean[] result = new boolean[8];
+    for (int i = 0; i < 8; i++) {
+      result[i] = src[i * 2] || src[i * 2 + 1];
+    }
+    return result;
+  }
+
+  /** Converts some downstrokes (even positions) into upstrokes (odd positions). */
+  private static boolean[] applyUpstrokes(boolean[] pattern) {
+    boolean[] result = Arrays.copyOf(pattern, pattern.length);
+    for (int i = 0; i < result.length - 1; i += 2) {
+      if (result[i]) {
+        // Add an upstroke on the following odd slot
+        result[i + 1] = true;
+      }
+    }
+    return result;
+  }
+
+  /** Removes every other active strum slot (JAZZ density reduction). */
+  private static boolean[] jazzFilter(boolean[] pattern) {
+    boolean[] result = Arrays.copyOf(pattern, pattern.length);
+    int activeCount = 0;
+    for (int i = 0; i < result.length; i++) {
+      if (result[i]) {
+        if (activeCount % 2 == 1) {
+          result[i] = false; // mute every second active strum
+        }
+        activeCount++;
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/Subdivision.java
+++ b/src/main/java/com/motifgen/guitar/backing/Subdivision.java
@@ -1,0 +1,40 @@
+package com.motifgen.guitar.backing;
+
+/**
+ * Rhythmic subdivision levels used by the {@link RhythmDensityPlanner}.
+ *
+ * <p>Ordinal order runs from coarsest (WHOLE) to finest (SIXTEENTH).
+ */
+public enum Subdivision {
+  WHOLE,
+  HALF,
+  QUARTER,
+  EIGHTH,
+  SIXTEENTH;
+
+  /**
+   * Returns the number of ticks this subdivision spans given a quarter-note resolution.
+   *
+   * @param ppq ticks per quarter note (pulses per quarter)
+   * @return ticks for this subdivision
+   */
+  public int ticksPerBeat(int ppq) {
+    return switch (this) {
+      case WHOLE      -> ppq * 4;
+      case HALF       -> ppq * 2;
+      case QUARTER    -> ppq;
+      case EIGHTH     -> ppq / 2;
+      case SIXTEENTH  -> ppq / 4;
+    };
+  }
+
+  /** Steps down one level (coarser); returns this if already at WHOLE. */
+  public Subdivision stepDown() {
+    return ordinal() == 0 ? this : values()[ordinal() - 1];
+  }
+
+  /** Steps up one level (finer); returns this if already at SIXTEENTH. */
+  public Subdivision stepUp() {
+    return ordinal() == values().length - 1 ? this : values()[ordinal() + 1];
+  }
+}

--- a/src/main/java/com/motifgen/guitar/backing/VoicedChord.java
+++ b/src/main/java/com/motifgen/guitar/backing/VoicedChord.java
@@ -1,0 +1,16 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Note;
+
+import java.util.List;
+
+/**
+ * A chord slot after voicing and strum-pattern application: a start tick plus
+ * the concrete {@link Note} objects (with actual MIDI pitches, velocities, and
+ * durations derived from the strum grid).
+ *
+ * @param startTick absolute start tick of this chord event
+ * @param notes     concrete note events; may be empty if the strum pattern is all-rest
+ *                  at this position
+ */
+public record VoicedChord(long startTick, List<Note> notes) {}

--- a/src/main/java/com/motifgen/guitar/backing/VoicingType.java
+++ b/src/main/java/com/motifgen/guitar/backing/VoicingType.java
@@ -1,0 +1,22 @@
+package com.motifgen.guitar.backing;
+
+/**
+ * Chord voicing styles available to the {@link GuitarChordVoicer}.
+ *
+ * <ul>
+ *   <li>POWER   — root + fifth only (power chord)</li>
+ *   <li>OPEN    — open-position triad with open strings where possible</li>
+ *   <li>BARRE   — full barre-chord voicing</li>
+ *   <li>JAZZ    — extended/altered voicings; shell-voicing filter applied by StrumPattern</li>
+ *   <li>TRIAD   — three-note close-position triad</li>
+ *   <li>SHELL   — root + third + seventh only</li>
+ * </ul>
+ */
+public enum VoicingType {
+  POWER,
+  OPEN,
+  BARRE,
+  JAZZ,
+  TRIAD,
+  SHELL
+}

--- a/src/main/java/com/motifgen/loader/MidiLoader.java
+++ b/src/main/java/com/motifgen/loader/MidiLoader.java
@@ -44,7 +44,15 @@ public class MidiLoader {
                 })
                 .toList();
 
-        return new Motif(trimmed, bars, beatsPerBar, ticksPerBeat);
+        // Use the actual note content to determine bar count so that a short file
+        // (e.g. 1-bar motif) is loaded with bars=1 rather than the caller's requested
+        // bars=4. This lets MotifLengthMatcher tile the motif up to phrase length.
+        long lastNoteTick = trimmed.stream().mapToLong(Note::endTick).max().orElse(0L);
+        int actualBars = (int) Math.max(1,
+                (lastNoteTick + ticksPerBar - 1) / ticksPerBar);
+        int useBars = Math.min(bars, actualBars);
+
+        return new Motif(trimmed, useBars, beatsPerBar, ticksPerBeat);
     }
 
     private static List<Note> extractNotes(Sequence sequence, int ticksPerBeat) {

--- a/src/test/java/com/motifgen/guitar/backing/BackingTrackTest.java
+++ b/src/test/java/com/motifgen/guitar/backing/BackingTrackTest.java
@@ -1,0 +1,311 @@
+package com.motifgen.guitar.backing;
+
+import com.motifgen.model.Motif;
+import com.motifgen.model.Note;
+import com.motifgen.model.Sentence;
+import com.motifgen.sentiment.SentimentProfile;
+import com.motifgen.theory.KeySignature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TDD tests for GitHub issue #18 — Rhythm Guitar Backing Track.
+ *
+ * <p>Covers all 8 acceptance-criteria scenarios.
+ */
+class BackingTrackTest {
+
+  // -----------------------------------------------------------------------
+  // Shared fixtures
+  // -----------------------------------------------------------------------
+
+  private Sentence sentence;
+  private SentimentProfile happyProfile;
+  private SentimentProfile sadProfile;
+  private KeySignature cMajor;
+
+  @BeforeEach
+  void setUp() {
+    // 4-bar motif, 4/4, 480 ppq
+    int ppq = 480;
+    List<Note> notes = List.of(
+        new Note(60, 0, ppq, 80),       // C4
+        new Note(62, ppq, ppq, 75),      // D4
+        new Note(64, ppq * 2, ppq, 70),  // E4
+        new Note(65, ppq * 3, ppq, 65)   // F4
+    );
+    Motif motif = new Motif(notes, 4, 4, ppq);
+    sentence = new Sentence(List.of(motif), "a a' b a''", "C major", 75.0);
+    happyProfile = SentimentProfile.fromLabel("HAPPY");
+    sadProfile = SentimentProfile.fromLabel("SAD");
+    cMajor = KeySignature.major(0);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 1: MIDI channel 2 (index 1), program 25, register 40–76
+  // -----------------------------------------------------------------------
+
+  @Test
+  void backingTrackHasCorrectChannelAndProgram() {
+    BackingTrack track = BackingTrackGenerator.generate(sentence, happyProfile);
+    assertNotNull(track);
+    // All notes must be on channel index 1 (= MIDI channel 2)
+    track.notes().forEach(n ->
+        assertEquals(1, n.channel(), "Expected channel index 1 (MIDI ch 2)"));
+    assertEquals(25, track.program(), "Expected GM program 25 (Acoustic Guitar)");
+  }
+
+  @Test
+  void backingTrackNotesPitchInRegister() {
+    BackingTrack track = BackingTrackGenerator.generate(sentence, happyProfile);
+    track.notes().forEach(n -> {
+      if (!n.note().isRest()) {
+        int pitch = n.note().pitch();
+        assertTrue(pitch >= 40 && pitch <= 76,
+            "Pitch " + pitch + " outside MIDI register 40-76 (E2-E5)");
+      }
+    });
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 2: Five HarmonyApproach values exist
+  // -----------------------------------------------------------------------
+
+  @Test
+  void harmonyApproachEnumHasFiveValues() {
+    assertEquals(5, HarmonyApproach.values().length,
+        "Expected exactly 5 HarmonyApproach variants");
+  }
+
+  @Test
+  void harmonyApproachGeneratesChords() {
+    List<Note> melodyNotes = sentence.getAllNotes();
+    for (HarmonyApproach approach : HarmonyApproach.values()) {
+      List<ChordSlot> slots = approach.generateChords(melodyNotes, cMajor, happyProfile);
+      assertNotNull(slots, approach + " returned null");
+      assertFalse(slots.isEmpty(), approach + " returned empty chord list");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 3: RhythmDensityPlanner
+  // -----------------------------------------------------------------------
+
+  @Test
+  void rhythmDensityPlannerLowArousalGivesWholeOrHalf() {
+    SentimentProfile lowArousal = SentimentProfile.fromVA(0.5, 0.1); // arousal 0.1 → WHOLE
+    RhythmDensityPlan plan = RhythmDensityPlanner.plan(lowArousal, "A", sentence);
+    assertTrue(
+        plan.subdivision() == Subdivision.WHOLE || plan.subdivision() == Subdivision.HALF,
+        "Low arousal should yield WHOLE or HALF, got " + plan.subdivision());
+  }
+
+  @Test
+  void rhythmDensityPlannerHighArousalGivesEighthOrSixteenth() {
+    SentimentProfile highArousal = SentimentProfile.fromVA(0.8, 0.9); // arousal 0.9 → SIXTEENTH
+    RhythmDensityPlan plan = RhythmDensityPlanner.plan(highArousal, "B", sentence);
+    assertTrue(
+        plan.subdivision() == Subdivision.EIGHTH || plan.subdivision() == Subdivision.SIXTEENTH,
+        "High arousal should yield EIGHTH or SIXTEENTH, got " + plan.subdivision());
+  }
+
+  @Test
+  void rhythmDensityPlannerSectionMultipliersApplied() {
+    SentimentProfile mid = SentimentProfile.fromVA(0.5, 0.5); // arousal 0.5 → QUARTER
+    // INTRO multiplier 0.7 should step subdivision down from QUARTER
+    RhythmDensityPlan introPlan = RhythmDensityPlanner.plan(mid, "INTRO", sentence);
+    RhythmDensityPlan aPlan = RhythmDensityPlanner.plan(mid, "A", sentence);
+    // INTRO should not exceed A in density
+    assertTrue(
+        introPlan.subdivision().ordinal() <= aPlan.subdivision().ordinal(),
+        "INTRO section should be equal or sparser than A section");
+  }
+
+  @Test
+  void rhythmDensityPlanReturnsPlan() {
+    RhythmDensityPlan plan = RhythmDensityPlanner.plan(happyProfile, "A", sentence);
+    assertNotNull(plan);
+    assertNotNull(plan.subdivision());
+    assertTrue(plan.changesPerBar() >= 1);
+    assertNotNull(plan.accentBeats());
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 4: StrumPattern archetypes and modifications
+  // -----------------------------------------------------------------------
+
+  @Test
+  void strumPatternHasSevenArchetypes() {
+    // All archetype names exist without throwing
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.DRIVING));
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.FOLK));
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.FUNK));
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.BALLAD));
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.REGGAE));
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.POWER));
+    assertDoesNotThrow(() -> StrumPattern.forArchetype(StrumPattern.Archetype.ARPEGGIO));
+    assertEquals(7, StrumPattern.Archetype.values().length);
+  }
+
+  @Test
+  void strumPatternForSentimentReturnsNonEmpty() {
+    RhythmDensityPlan plan = RhythmDensityPlanner.plan(happyProfile, "A", sentence);
+    boolean[] pattern = StrumPattern.forSentiment(happyProfile, VoicingType.OPEN, 120, plan);
+    assertNotNull(pattern);
+    assertTrue(pattern.length > 0);
+    // At least some beats should be active
+    int active = 0;
+    for (boolean b : pattern) if (b) active++;
+    assertTrue(active > 0, "Strum pattern must have at least one active beat");
+  }
+
+  @Test
+  void strumPatternPowerEnsuresBeats0And4() {
+    RhythmDensityPlan plan = new RhythmDensityPlan(Subdivision.EIGHTH, 2, List.of(0, 4));
+    boolean[] pattern = StrumPattern.forSentiment(sadProfile, VoicingType.POWER, 100, plan);
+    // beats 0 and 4 must be strummed in an 8-slot pattern
+    if (pattern.length >= 8) {
+      assertTrue(pattern[0], "Beat 0 must be strummed in POWER mode");
+      assertTrue(pattern[4], "Beat 4 must be strummed in POWER mode");
+    }
+  }
+
+  @Test
+  void strumPatternHighTempoSixteenthSimplifiestoEighth() {
+    // tempo > 160 + SIXTEENTH should simplify
+    RhythmDensityPlan plan = new RhythmDensityPlan(Subdivision.SIXTEENTH, 4, List.of(0, 2, 4, 6));
+    boolean[] pattern = StrumPattern.forSentiment(happyProfile, VoicingType.OPEN, 180, plan);
+    // Result should be at most EIGHTH granularity (length <= 8 per bar)
+    assertTrue(pattern.length <= 8, "High tempo should simplify SIXTEENTH to EIGHTH (max 8 slots)");
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 5: Voicing engine in range 40–76 using GuitarFingering
+  // -----------------------------------------------------------------------
+
+  @Test
+  void guitarChordVoicerProducesVoicedChordsInRange() {
+    List<Note> melodyNotes = sentence.getAllNotes();
+    List<ChordSlot> slots =
+        HarmonyApproach.STATIC_PEDAL.generateChords(melodyNotes, cMajor, happyProfile);
+    List<VoicedChord> voiced = GuitarChordVoicer.voice(slots, VoicingType.OPEN, 480);
+    assertFalse(voiced.isEmpty());
+    for (VoicedChord vc : voiced) {
+      for (Note n : vc.notes()) {
+        if (!n.isRest()) {
+          int pitch = n.pitch();
+          assertTrue(pitch >= 40 && pitch <= 76,
+              "Voiced pitch " + pitch + " outside MIDI register 40-76");
+        }
+      }
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 6: BackingTrackSelector picks highest scoring candidate
+  // -----------------------------------------------------------------------
+
+  @Test
+  void backingTrackSelectorReturnsHighestScorer() {
+    BackingTrack track = BackingTrackSelector.select(sentence, happyProfile);
+    assertNotNull(track);
+    // Score should be in 0-100 range
+    assertTrue(track.combinedScore() >= 0.0 && track.combinedScore() <= 100.0,
+        "Combined score should be 0-100, got " + track.combinedScore());
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 7: BackingConsonanceScorer uses CONSONANCE_TABLE, normalised 0-100
+  // -----------------------------------------------------------------------
+
+  @Test
+  void consonanceScorerPerfectOctaveScoresHighest() {
+    // Unison interval (0) has value 1.0 in the table → highest consonance
+    List<Note> melodyNotes = sentence.getAllNotes();
+    List<ChordSlot> slots =
+        HarmonyApproach.STATIC_PEDAL.generateChords(melodyNotes, cMajor, happyProfile);
+    // Build a voiced chord matching the melody note exactly (unison = max consonance)
+    int ppq = 480;
+    VoicedChord vc = new VoicedChord(0,
+        List.of(new Note(60, 0, ppq, 80))); // C4 = same pitch class as melody
+    double score = BackingConsonanceScorer.score(List.of(vc), melodyNotes, ppq);
+    assertTrue(score >= 0.0 && score <= 100.0,
+        "Consonance score should be 0-100, got " + score);
+  }
+
+  @Test
+  void consonanceScorerReturnsValueInRange() {
+    List<Note> melodyNotes = sentence.getAllNotes();
+    List<ChordSlot> slots =
+        HarmonyApproach.FUNCTIONAL_DIATONIC.generateChords(melodyNotes, cMajor, happyProfile);
+    int ppq = 480;
+    List<VoicedChord> voiced = GuitarChordVoicer.voice(slots, VoicingType.OPEN, ppq);
+    double score = BackingConsonanceScorer.score(voiced, melodyNotes, ppq);
+    assertTrue(score >= 0.0 && score <= 100.0,
+        "Consonance score must be 0-100, got " + score);
+  }
+
+  // -----------------------------------------------------------------------
+  // Scenario 8: BackingCatchinessScorer weighted formula
+  // -----------------------------------------------------------------------
+
+  @Test
+  void catchinessScorerReturnsValueInRange() {
+    List<Note> melodyNotes = sentence.getAllNotes();
+    int ppq = 480;
+    List<ChordSlot> slots =
+        HarmonyApproach.STATIC_PEDAL.generateChords(melodyNotes, cMajor, happyProfile);
+    RhythmDensityPlan plan = RhythmDensityPlanner.plan(happyProfile, "A", sentence);
+    boolean[] strumPat = StrumPattern.forSentiment(happyProfile, VoicingType.OPEN, 120, plan);
+    List<VoicedChord> voiced = GuitarChordVoicer.voice(slots, VoicingType.OPEN, ppq);
+    double score = BackingCatchinessScorer.score(sentence, voiced, strumPat, ppq);
+    assertTrue(score >= 0.0 && score <= 100.0,
+        "Catchiness score must be 0-100, got " + score);
+  }
+
+  // -----------------------------------------------------------------------
+  // Subdivision enum
+  // -----------------------------------------------------------------------
+
+  @Test
+  void subdivisionTicksPerBeatCorrect() {
+    int ppq = 480;
+    assertEquals(ppq * 4, Subdivision.WHOLE.ticksPerBeat(ppq));
+    assertEquals(ppq * 2, Subdivision.HALF.ticksPerBeat(ppq));
+    assertEquals(ppq, Subdivision.QUARTER.ticksPerBeat(ppq));
+    assertEquals(ppq / 2, Subdivision.EIGHTH.ticksPerBeat(ppq));
+    assertEquals(ppq / 4, Subdivision.SIXTEENTH.ticksPerBeat(ppq));
+  }
+
+  // -----------------------------------------------------------------------
+  // VoicingType enum
+  // -----------------------------------------------------------------------
+
+  @Test
+  void voicingTypeEnumHasSixValues() {
+    assertEquals(6, VoicingType.values().length,
+        "Expected 6 VoicingType variants");
+  }
+
+  // -----------------------------------------------------------------------
+  // BackingTrackGenerator facade
+  // -----------------------------------------------------------------------
+
+  @Test
+  void backingTrackGeneratorProducesNonEmptyTrack() {
+    BackingTrack track = BackingTrackGenerator.generate(sentence, happyProfile);
+    assertNotNull(track);
+    assertFalse(track.notes().isEmpty(), "Generated backing track must have notes");
+  }
+
+  @Test
+  void backingTrackGeneratorSadProfileProducesTrack() {
+    BackingTrack track = BackingTrackGenerator.generate(sentence, sadProfile);
+    assertNotNull(track);
+    assertFalse(track.notes().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a second MIDI track (channel 2, program 25 Acoustic Guitar, register E2–E5) generated alongside the melody
- Implements five harmony approaches (Functional Diatonic, Modal Colour, Static Pedal, Jazz Shell, Implied Harmony) × six voicing types (POWER, OPEN, BARRE, JAZZ, TRIAD, SHELL) = 30 candidates per generation
- Selects the top candidate automatically by combined score: 0.5 × consonance + 0.5 × catchiness (extended formula includes rhythmic interlock, hook reinforcement, harmonic interest)
- Rhythm density and strumming pattern (7 archetypes: DRIVING/FOLK/FUNK/BALLAD/REGGAE/POWER/ARPEGGIO) are planned per arousal, structural section, and melody density

Closes #18

## Design

New `guitar/backing/` package with 15 classes. `BackingTrackGenerator` is a facade — `MotifGen` calls `generate(sentence, profile)` and passes the result to a new `MidiExporter.export(Sentence, BackingTrack, File)` overload that writes a Type-1 SMF. Existing `MidiExporter.export(Sentence, File)` overload is untouched. The existing `GuitarFingering` DP path-finder is reused verbatim for chord voicing. `ChanneledNote` wraps `Note` with a 0-indexed channel field, keeping the core model unchanged.

## Test Coverage

- **Unit:** `BackingTrackTest` — 18 tests in `src/test/java/com/motifgen/guitar/backing/`, covering all 8 Gherkin acceptance criteria scenarios
- **E2E:** `RhythmGuitarE2ETest` — 7 tests (+ 5 parameterized) in `src/e2eTest/java/com/motifgen/`, verifying MIDI output structure, all 5 harmony approaches, arousal→density mapping, sentiment→pattern differentiation, selector non-nullability, and scorer range bounds
- **Total build:** 84 tests passing, JaCoCo coverage gates green

🤖 Generated with Claude Code SDLC workflow